### PR TITLE
Update Figurine to 2.0.0

### DIFF
--- a/scripts/post_install/customizable_post_install.sh
+++ b/scripts/post_install/customizable_post_install.sh
@@ -2214,13 +2214,13 @@ register_tool "fastfetch" true "$FUNC_VERSION"
 
 
 configure_figurine() {
-    local FUNC_VERSION="1.0"
+    local FUNC_VERSION="1.1"
     # description: Install Figurine (ASCII-art hostname banner) and wire it into the SSH login flow.
     msg_info2 "$(translate "Installing and configuring Figurine...")"
     # `FIGURINE_VERSION` env var allows pinning to a specific release;
     # default tracks the last tested upstream tag. Audit Tier 6 —
     # recursos remotos sin pinning de versión.
-    local version="${FIGURINE_VERSION:-1.3.0}"
+    local version="${FIGURINE_VERSION:-2.0.0}"
     local file="figurine_linux_amd64_v${version}.tar.gz"
     local url="https://github.com/arsham/figurine/releases/download/v${version}/${file}"
     local temp_dir; temp_dir=$(mktemp -d)

--- a/web/app/docs/post-install/optional/page.tsx
+++ b/web/app/docs/post-install/optional/page.tsx
@@ -30,6 +30,7 @@ export const metadata: Metadata = {
   },
 }
 
+
 function StepNumber({ number }: { number: number }) {
   return (
     <div className="inline-flex items-center justify-center w-8 h-8 mr-3 text-white bg-blue-500 rounded-full">
@@ -315,7 +316,7 @@ echo "clear && fastfetch" >> ~/.bashrc
         <strong>What it does:</strong>
       </p>
       <ul className="list-disc pl-5 mb-4">
-        <li>Downloads and installs Figurine v1.3.0 from GitHub</li>
+        <li>Downloads and installs Figurine v2.0.0 from GitHub</li>
         <li>Creates a welcome message that displays your hostname in 3D ASCII art when you log in</li>
         <li>Automatically removes any previous Figurine installation if present</li>
         <li>Sets up the welcome message to run automatically at login</li>
@@ -352,7 +353,7 @@ if command -v figurine &> /dev/null; then
 fi
 
 # Download and install Figurine
-version="1.3.0"
+version="2.0.0"
 file="figurine_linux_amd64_v\${version}.tar.gz"
 url="https://github.com/arsham/figurine/releases/download/v\${version}/\${file}"
 wget -qO "/tmp/\${file}" "\${url}"
@@ -384,4 +385,3 @@ chmod +x "/etc/profile.d/figurine.sh"
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary

This PR updates the Figurine installer used by the customizable post-install script from `v1.3.0` to `v2.0.0`.

Changes included:

- Bump the default `FIGURINE_VERSION` fallback from `1.3.0` to `2.0.0`.
- Bump the `configure_figurine` function version from `1.0` to `1.1` so ProxMenux can detect the updated optimization.
- Update the post-install optional settings documentation to mention Figurine `v2.0.0`.

## Why

Figurine `v2.0.0` was published upstream on 2026-05-06.

The release keeps the expected Linux amd64 asset name used by the ProxMenux installer:

- `figurine_linux_amd64_v2.0.0.tar.gz`

Upstream release notes mention a Go toolchain upgrade and removal of the Cobra/Viper dependencies.

Reference: https://github.com/arsham/figurine/releases/tag/v2.0.0

## Tested

Tested on:

- Host: `aiclaw`
- Hardware: AZW SER9
- OS: Debian GNU/Linux 13 (trixie)
- Proxmox VE: 9.1.0
- pve-manager: 9.1.11
- Kernel: Linux 7.0.2-2-pve

Test results:

- Before: `figurine version v1.3.0 (d51c245)`
- Ran `configure_figurine` from the updated script.
- After: `figurine version v2.0.0 (bd1117d)`
- Confirmed `/etc/profile.d/figurine.sh` still points to `/usr/local/bin/figurine -f "3d.flf" $(hostname)`.
- Confirmed generated Figurine output was non-empty.
- Confirmed `installed_tools.json` registers `figurine` with function version `1.1` and source `custom`.

Validation:

- `bash -n scripts/post_install/customizable_post_install.sh`
- `git diff --check`

Note: web lint was not run locally because `web/node_modules` is not present in this checkout.
