### PR TITLE
Fix webhook loopback detection and update handoff

### DIFF
--- a/AppImage/scripts/flask_notification_routes.py
+++ b/AppImage/scripts/flask_notification_routes.py
@@ -191,6 +191,24 @@ def _bad_request(msg: str):
     return jsonify({'error': msg}), 400
 
 
+def _is_loopback_addr(value: str) -> bool:
+    """Return True for IPv4, IPv6 and IPv4-mapped loopback addresses.
+
+    When Flask is bound to ``::`` for dual-stack support, an HTTP request
+    sent to ``127.0.0.1`` can be reported as ``::ffff:127.0.0.1``. Treat it
+    as local so the PVE webhook keeps the intended localhost trust path.
+    """
+    try:
+        import ipaddress
+        addr = ipaddress.ip_address(value)
+        if addr.is_loopback:
+            return True
+        ipv4_mapped = getattr(addr, 'ipv4_mapped', None)
+        return bool(ipv4_mapped and ipv4_mapped.is_loopback)
+    except ValueError:
+        return value == 'localhost'
+
+
 def _validate_event_type(value: str) -> bool:
     return isinstance(value, str) and bool(_EVENT_TYPE_RE.match(value))
 
@@ -1225,7 +1243,7 @@ def proxmox_webhook():
     _reject = lambda code, error, status: (jsonify({'accepted': False, 'error': error}), status)
 
     client_ip = request.remote_addr or ''
-    is_localhost = client_ip in ('127.0.0.1', '::1')
+    is_localhost = _is_loopback_addr(client_ip)
 
     # CSRF defence-in-depth: reject `application/x-www-form-urlencoded`
     # bodies. PVE always sends `application/json`; form-encoded bodies

--- a/menu
+++ b/menu
@@ -79,8 +79,8 @@ check_updates_stable() {
 
         if curl -fsSL "$INSTALL_URL" -o "$INSTALL_SCRIPT"; then
             chmod +x "$INSTALL_SCRIPT"
-            bash "$INSTALL_SCRIPT" --update
-            return 0
+            # Replace this shell before the installer refreshes /usr/local/bin/menu.
+            exec bash "$INSTALL_SCRIPT" --update
         fi
     fi
 }
@@ -111,8 +111,8 @@ check_updates_beta() {
         local INSTALL_BETA_SCRIPT="$BASE_DIR/install_proxmenux_beta.sh"
         if curl -fsSL "$REPO_DEVELOP/install_proxmenux_beta.sh" -o "$INSTALL_BETA_SCRIPT"; then
             chmod +x "$INSTALL_BETA_SCRIPT"
-            bash "$INSTALL_BETA_SCRIPT" --update
-            return 0
+            # Replace this shell before the installer refreshes /usr/local/bin/menu.
+            exec bash "$INSTALL_BETA_SCRIPT" --update
         else
             msg_error "Could not download the beta installer from the develop branch."
         fi


### PR DESCRIPTION
## Summary
- Treat IPv4-mapped loopback addresses such as `::ffff:127.0.0.1` as local webhook callers.
- Keep the PVE webhook localhost trust path working when the monitor is bound to `::` for dual-stack support.
- Use `exec` when launching stable or beta updates from `menu`, so Bash stops reading the old `/usr/local/bin/menu` before the installer refreshes it.

## Bug triage
Checked the currently open issues labeled `bug`:

- #198: This PR addresses a likely Beta notification regression after dual-stack binding: localhost requests may arrive as IPv4-mapped IPv6 and were treated as remote, triggering the stricter remote webhook checks.
- #180: Fixed here. The update flow now replaces the running shell before the installer overwrites `menu`, avoiding mixed old/new script parsing during upgrade.
- #194: Already addressed on `develop` by selecting `http://`/`https://` from the SSL config and refreshing the PVE webhook URL after SSL changes.
- #192: Already addressed on `develop` by binding the Flask/gevent server to `::`.
- #179: Already addressed on `develop` with SR-IOV VF/PF detection and guards.
- #171: Already addressed on `develop` by allowing custom OpenAI-compatible endpoints to return their advertised model list without verified-list intersection.

Fixes #180
Addresses #198

## Validation
- `bash -n menu`
- `bash -n install_proxmenux.sh`
- `bash -n install_proxmenux_beta.sh`
- `python3 -m py_compile AppImage/scripts/flask_notification_routes.py`
- `find AppImage/scripts -maxdepth 1 -name '*.py' -print0 | xargs -0 python3 -m py_compile`
- `git diff --check`
- Loopback helper regression cases: 8/8 passing
  - `127.0.0.1`
  - `::1`
  - `::ffff:127.0.0.1`
  - `::ffff:7f00:1`
  - `localhost`
  - non-loopback IPv4/IPv6/invalid host negatives
