### PR TITLE
Hotfix: pagefind missing in web/package.json + AppImage build cache path

### DIFF
--- a/AppImage/scripts/build_appimage.sh
+++ b/AppImage/scripts/build_appimage.sh
@@ -16,7 +16,12 @@ APPIMAGE_NAME="ProxMenux-${VERSION}.AppImage"
 
 echo "🚀 Building ProxMenux Monitor AppImage v${VERSION} with hardware monitoring tools..."
 
-APPIMAGETOOL_CACHE="/var/cache/proxmenux-build/appimagetool"
+# Cache the downloaded appimagetool across builds. Prefer the XDG user
+# cache so this works the same way under root (local .50 build) and
+# under the non-root GitHub Actions runner — previously hardcoded to
+# /var/cache/, which the CI user can't write to (mkdir Permission
+# denied → build aborted before doing any actual work).
+APPIMAGETOOL_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/proxmenux-build/appimagetool"
 
 # Preserve a cached copy of appimagetool across builds. wget -q has bitten
 # us repeatedly when GitHub momentarily rate-limits or the runner has no

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -74,6 +74,7 @@
         "@types/node": "^22",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "pagefind": "^1.5.2",
         "postcss": "^8",
         "tailwindcss": "^3.4.17",
         "typescript": "^5"
@@ -946,6 +947,104 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
@@ -6706,6 +6805,25 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -79,6 +79,7 @@
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "pagefind": "^1.5.2",
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"


### PR DESCRIPTION
## Summary

Two CI workflows that auto-trigger on push to main failed right after PR #210 merged. This hotfix addresses both. No source code or user-facing change — workflow configuration only.

### `Deploy to GitHub Pages` (run 26711325254) — `pagefind: not found`

Next.js prerendered all 241 routes successfully, then the build pipeline ran `pagefind --site out` and bailed with exit 127. `pagefind` was not declared anywhere in `web/package.json`; the local pre-merge build only worked because the project root had its own `package.json` with pagefind as a devDep (the one we gitignored in #210 thinking it was redundant).

Fix: add `pagefind: ^1.5.2` to `web/package.json` devDependencies and regenerate `web/package-lock.json`. CI's `cd web && npm ci` will now put the binary in `web/node_modules/.bin/pagefind` where the existing `npm run build` script expects it.

### `Build ProxMenux Monitor AppImage` (run 26711325259) — `/var/cache` not writable

```
mkdir: cannot create directory '/var/cache/proxmenux-build': Permission denied
##[error]Process completed with exit code 1.
```

The cache path for `appimagetool` was hardcoded to `/var/cache/proxmenux-build/` in `AppImage/scripts/build_appimage.sh`. Writable when the script runs as root (the .50 lab host's manual build) but not as the unprivileged GitHub Actions runner. Switched to `${XDG_CACHE_HOME:-$HOME/.cache}/proxmenux-build/` — works identically in both environments.

## Test plan

- [x] Local rebuild from clean `node_modules`: `cd web && rm -rf node_modules && npm ci && npm run build` → 2804 files in `out/`, 231 pages indexed by pagefind, root redirect intact
- [x] No other dependencies changed in the lockfile (pagefind + its transitive platform packages only)

## After merge

`deploy.yml` should run cleanly and publish proxmenux.com/en/ with the new i18n web. `build-appimage.yml` should also pass the verification build (artifact only — the canonical 1.2.2 binary already shipped in PR #210 stays as-is in main).