### PR TITLE
Hotfix: trailingSlash:true so GitHub Pages serves /en/ and /es/

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -13,6 +13,18 @@ const withNextIntl = createNextIntlPlugin('./i18n/request.ts')
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "export",
+  // GitHub Pages serves a directory URL `/foo/` by looking for
+  // `out/foo/index.html`. Next.js's default static export with
+  // `trailingSlash: false` emits `out/foo.html` instead, which Pages
+  // only serves for the bare URL `/foo` (no trailing slash). The
+  // i18n root redirect points users at `/<defaultLocale>/` (with
+  // slash) — so every visitor would land on a 404. Enabling
+  // trailingSlash makes Next.js emit `out/<route>/index.html` for
+  // every page, including `out/en/index.html` and `out/es/index.html`
+  // so the locale roots load correctly. Internal `<Link>` URLs from
+  // next-intl already include the trailing slash, so this aligns
+  // export, runtime navigation and Pages serving.
+  trailingSlash: true,
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary

Deploy from #211 went live but every visitor hits a 404. Root cause is the Next.js export emitting `out/<route>.html` instead of `out/<route>/index.html`, which is what GitHub Pages expects when the URL has a trailing slash.

The i18n root redirect points users at `/<defaultLocale>/` (with slash) because that is what next-intl's `<Link>` components generate. Pages looks for `out/en/index.html`, doesn't find it (the export emitted `out/en.html` instead), and serves `out/404.html` — that is the Next.js 404 template the user saw.

## Fix

One-line change in `web/next.config.mjs`: `trailingSlash: true`.

This makes Next.js emit `out/<route>/index.html` for every page, including:
- `out/en/index.html` and `out/es/index.html` (locale roots)
- `out/en/docs/monitor/dashboard/settings/index.html` (every nested doc page)
- `out/en/changelog/index.html`, `out/en/guides/<slug>/index.html`, etc.

The root redirect at `out/index.html` already pointed at `/en/` (with slash) so it now lands on the correct file.

## Test plan

- [x] Local rebuild from clean state — 232 pages indexed, every locale + doc + guide URL resolves to its own `index.html`
- [x] Root `out/index.html` still redirects to `/en/` via meta refresh
- [x] `out/en.html` no longer exists (replaced by directory `out/en/`)

## Why this slipped through

Previous PR's local smoke check verified the build *compiled* successfully but did not verify that GitHub Pages would *serve* the output correctly. The `out/en/index.html` MISSING line in the earlier checker was flagged as a "false alarm" because `out/en.html` existed — but Pages does not auto-rewrite the trailing slash, so the URL `/en/` does not actually map to `/en.html`. Lesson added to memory.