### PR TITLE
Hotfix: doc nav + sidebar active-page broken after trailingSlash

### DIFF
--- a/web/components/DocSidebar.tsx
+++ b/web/components/DocSidebar.tsx
@@ -32,6 +32,17 @@ function collectHrefs(items: SubMenuItem[]): string[] {
   return out
 }
 
+// Next.js is configured with `trailingSlash: true` (required so GitHub
+// Pages serves /foo/ as foo/index.html). That makes usePathname() return
+// `/docs/.../page/` while sidebar hrefs are declared without the slash,
+// so a naive `pathname === item.href` always fails and the active-item
+// highlight + active-section auto-open both break. Strip the trailing
+// slash on both sides before comparing.
+function stripTrailingSlash(s: string): string {
+  if (!s || s === "/") return s
+  return s.replace(/\/+$/, "")
+}
+
 export const sidebarItems: MenuItem[] = [
   { title: "Introduction", i18nKey: "introduction", href: "/docs/introduction" },
   { title: "Installation", i18nKey: "installation", href: "/docs/installation" },
@@ -273,6 +284,7 @@ export const sidebarItems: MenuItem[] = [
 
 export default function DocSidebar() {
   const pathname = usePathname()
+  const currentPath = stripTrailingSlash(pathname)
   const [openSections, setOpenSections] = useState<{ [key: string]: boolean }>({})
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const t = useTranslations("docSidebar")
@@ -313,9 +325,10 @@ export default function DocSidebar() {
   const renderSubItem = (subItem: SubMenuItem, depth: number) => {
     const hasChildren = !!subItem.submenu && subItem.submenu.length > 0
     if (hasChildren) {
-      const descendantHrefs = collectHrefs(subItem.submenu!)
+      const descendantHrefs = collectHrefs(subItem.submenu!).map(stripTrailingSlash)
+      const subItemPath = stripTrailingSlash(subItem.href)
       const containsActivePage =
-        subItem.href === pathname || descendantHrefs.includes(pathname)
+        subItemPath === currentPath || descendantHrefs.includes(currentPath)
       const sectionKey = `${subItem.href}__${subItem.title}`
       const isOpen = (openSections[sectionKey] ?? containsActivePage) || false
       return (
@@ -325,7 +338,7 @@ export default function DocSidebar() {
               href={subItem.href}
               onClick={() => setIsMobileMenuOpen(false)}
               className={`flex-1 block p-2 rounded-l ${
-                pathname === subItem.href
+                currentPath === subItemPath
                   ? "bg-blue-500 text-white"
                   : containsActivePage
                     ? "bg-blue-50 text-blue-900 font-medium"
@@ -339,7 +352,7 @@ export default function DocSidebar() {
               aria-label={isOpen ? "Collapse" : "Expand"}
               onClick={() => toggleSection(sectionKey)}
               className={`px-2 flex items-center rounded-r ${
-                containsActivePage && pathname !== subItem.href
+                containsActivePage && currentPath !== subItemPath
                   ? "bg-blue-50 text-blue-900 hover:bg-blue-100"
                   : "text-gray-500 hover:bg-gray-200"
               }`}
@@ -361,7 +374,7 @@ export default function DocSidebar() {
         <Link
           href={subItem.href}
           className={`block p-2 rounded ${
-            pathname === subItem.href
+            currentPath === stripTrailingSlash(subItem.href)
               ? "bg-blue-500 text-white"
               : "text-gray-700 hover:bg-gray-200 hover:text-gray-900"
           }`}
@@ -375,7 +388,7 @@ export default function DocSidebar() {
 
   const renderMenuItem = (item: MenuItem) => {
     if (item.submenu) {
-      const containsActivePage = collectHrefs(item.submenu).includes(pathname)
+      const containsActivePage = collectHrefs(item.submenu).map(stripTrailingSlash).includes(currentPath)
       const isOpen = (openSections[item.title] ?? containsActivePage) || false
       return (
         <li key={item.title} className="mb-2">
@@ -403,7 +416,7 @@ export default function DocSidebar() {
           <Link
             href={item.href!}
             className={`block p-2 rounded ${
-              pathname === item.href ? "bg-blue-500 text-white" : "text-gray-700 hover:bg-gray-200 hover:text-gray-900"
+              currentPath === stripTrailingSlash(item.href!) ? "bg-blue-500 text-white" : "text-gray-700 hover:bg-gray-200 hover:text-gray-900"
             }`}
             onClick={() => setIsMobileMenuOpen(false)}
           >

--- a/web/components/ui/doc-navigation.tsx
+++ b/web/components/ui/doc-navigation.tsx
@@ -92,7 +92,19 @@ export function DocNavigation({ className }: DocNavigationProps) {
     allPages.push(p)
   }
 
-  const currentPageIndex = allPages.findIndex((page) => page.href === pathname)
+  // Normalize trailing slashes before comparing. Next.js is configured
+  // with `trailingSlash: true` (so GitHub Pages serves `/foo/` as
+  // `foo/index.html`), which means usePathname() returns
+  // `/docs/.../page/` while sidebarItems declares hrefs as
+  // `/docs/.../page` (no trailing slash). Without this normalization
+  // findIndex always returned -1 → prevPage was null and nextPage was
+  // allPages[0] (Introduction) on every page, so the bottom Previous/Next
+  // bar showed "Next: Introduction" everywhere regardless of the route.
+  const stripTrailingSlash = (s: string) => (s !== "/" ? s.replace(/\/+$/, "") : s)
+  const normalizedPathname = stripTrailingSlash(pathname)
+  const currentPageIndex = allPages.findIndex(
+    (page) => stripTrailingSlash(page.href) === normalizedPathname,
+  )
 
   const prevPage = currentPageIndex > 0 ? allPages[currentPageIndex - 1] : null
   const nextPage = currentPageIndex < allPages.length - 1 ? allPages[currentPageIndex + 1] : null


### PR DESCRIPTION
## Summary

PR #212 added \`trailingSlash: true\` (so GitHub Pages serves the locale roots). That broke five URL comparisons in the doc nav components because \`usePathname()\` now returns \`/docs/.../page/\` while sidebar hrefs are declared without the slash, so equality checks silently failed everywhere.

## Symptoms

- **Bottom navigation bar**: every doc page showed "Next: Introduction" regardless of where the user was. With \`findIndex\` returning -1, \`prevPage\` was null and \`nextPage = allPages[0]\` (Introduction).
- **Sidebar active item**: the current page was never highlighted blue in the sidebar.
- **Sidebar active section**: navigating directly to a nested page didn't auto-open its parent section.
- **Leaf items without submenu**: silent miss on the active-item highlight too.

## Fix

Added \`stripTrailingSlash\` helper + a derived \`currentPath\` constant. The 5 comparisons now match correctly regardless of which side carries the slash. \`collectHrefs(...)\` results are normalized at the point of use so \`.includes(currentPath)\` behaves consistently.

## Test plan

- [x] Local build with the fix: \`npm run build\` → 232 pages indexed, no errors.
- [x] No other \`pathname ===\` comparisons left in develop's grep.