### PR TITLE
Self-heal monitor unit on menu launch + revert v1.2.2.1 bump (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 Single-purpose patch for [#222](https://github.com/MacRimi/ProxMenux/issues/222). Users updating from any v1.2.1.x stable installation to v1.2.2 hit a `proxmenux-monitor.service` that refused to start with `status=203/EXEC`. The v1.2.2 install layout extracts the AppImage into `/usr/local/share/proxmenux/monitor-app/` and runs `AppRun` out of that directory — but the installer's update path was reusing whichever unit file was already present and only refreshing the unit on a fresh install, so the inherited unit kept its old `ExecStart=/usr/local/share/proxmenux/ProxMenux-Monitor.AppImage` line. That path used to be a FUSE-mounted AppImage run, which v1.2.2 deliberately moved away from to clear a Wazuh rule-521 false positive on `/tmp/.mount_*`; under PVE 9.x / Debian 13 the bare AppImage failed to exec and the service entered the activating loop. The installer now always rewrites the unit to point at `AppRun` on every update — idempotent for installs whose unit is already correct, recovering for those whose isn't.
 
+The `menu` launcher additionally self-heals on startup: if it detects the exact broken fingerprint (unit `ExecStart` pointing at the bare AppImage AND the extracted `AppRun` already present on disk) it rewrites the unit and bounces the service before showing the update prompt, so a user who dismisses the update by reflex still ends up with a working Monitor.
+
 To recover an existing broken v1.2.2 install without waiting for the update prompt, run the installer manually once: `bash -c "$(wget -qLO - https://raw.githubusercontent.com/MacRimi/ProxMenux/main/install_proxmenux.sh)"`.
 
 ---

--- a/lang/es/CHANGELOG.md
+++ b/lang/es/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 Parche puntual para [#222](https://github.com/MacRimi/ProxMenux/issues/222). Los usuarios que actualizaban desde una instalación v1.2.1.x estable a v1.2.2 se encontraban con un `proxmenux-monitor.service` que no arrancaba con `status=203/EXEC`. El layout de instalación de v1.2.2 extrae el AppImage en `/usr/local/share/proxmenux/monitor-app/` y ejecuta `AppRun` desde ese directorio — pero el path de update del installer reutilizaba la unit file existente y solo refrescaba la unit en instalación nueva, así que la unit heredada conservaba su `ExecStart=/usr/local/share/proxmenux/ProxMenux-Monitor.AppImage` antiguo. Ese path era un AppImage montado por FUSE, algo que v1.2.2 abandonó deliberadamente para eliminar un falso positivo de la regla 521 de Wazuh sobre `/tmp/.mount_*`; bajo PVE 9.x / Debian 13 ejecutar el AppImage directamente fallaba y el servicio entraba en bucle de activación. El installer ahora reescribe la unit para que apunte a `AppRun` en cada update — idempotente para instalaciones cuya unit ya es correcta, recuperando las que no lo son.
 
+El lanzador `menu` se auto-repara además al arrancar: si detecta la huella exacta del bug (la unit con `ExecStart` apuntando al AppImage directo Y el `AppRun` extraído ya presente en disco) reescribe la unit y reinicia el servicio antes de mostrar el aviso de actualización, de modo que un usuario que descarte el update por reflejo termine con el Monitor funcionando.
+
 Para recuperar una instalación v1.2.2 ya rota sin esperar al aviso de actualización, ejecuta el installer manualmente una vez: `bash -c "$(wget -qLO - https://raw.githubusercontent.com/MacRimi/ProxMenux/main/install_proxmenux.sh)"`.
 
 ---

--- a/menu
+++ b/menu
@@ -46,6 +46,70 @@ is_beta() {
     [[ "$beta_flag" == "active" ]]
 }
 
+# ── Recover broken Monitor unit before anything else ──────
+#
+# v1.2.2 changed the AppImage layout: the binary is extracted to
+# /usr/local/share/proxmenux/monitor-app/ and the systemd unit
+# executes AppRun out of that directory. The install_proxmenux.sh
+# update path before v1.2.2.1 only rewrote the unit on fresh installs,
+# so every user updating from v1.2.1 stable inherited the old unit
+# whose ExecStart still pointed at the bare AppImage. On PVE 9.x /
+# Debian 13 that bare AppImage hits status=203/EXEC immediately and
+# the service enters the activating loop reported in #222.
+#
+# Re-running the new installer fixes it permanently, but the update
+# prompt below uses --defaultno so a user pressing Enter by reflex
+# stays broken. Patch the unit defensively at every menu launch: if
+# the bug's exact fingerprint is present (unit ExecStart matches the
+# bare AppImage path AND the extracted AppRun already exists) we
+# silently rewrite the unit and bounce the service. The check is a
+# no-op for healthy installs and for hosts that never installed the
+# Monitor at all, so it's safe to run unconditionally.
+auto_repair_monitor_unit() {
+    local unit_file="/etc/systemd/system/proxmenux-monitor.service"
+    local extracted_runtime="/usr/local/share/proxmenux/monitor-app"
+    local apprun="$extracted_runtime/AppRun"
+    local bare_appimage="/usr/local/share/proxmenux/ProxMenux-Monitor.AppImage"
+
+    [[ -f "$unit_file" && -x "$apprun" ]] || return 0
+    grep -q "^ExecStart=${bare_appimage}\$" "$unit_file" || return 0
+
+    local port working_dir
+    port=$(awk -F'"' '/^Environment="PORT=/ {print $2; exit}' "$unit_file" 2>/dev/null \
+        | sed 's/^PORT=//')
+    [[ -z "$port" ]] && port="8008"
+    working_dir=$(awk -F'=' '/^WorkingDirectory=/ {print $2; exit}' "$unit_file" 2>/dev/null)
+    [[ -z "$working_dir" ]] && working_dir="/usr/local/share/proxmenux"
+
+    cat > "$unit_file" <<EOF
+[Unit]
+Description=ProxMenux Monitor - Web Dashboard
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=$working_dir
+ExecStart=$apprun
+Restart=on-failure
+RestartSec=10
+Environment="PORT=$port"
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    systemctl daemon-reload >/dev/null 2>&1
+    systemctl restart proxmenux-monitor.service >/dev/null 2>&1
+    sleep 2
+
+    if systemctl is-active --quiet proxmenux-monitor.service 2>/dev/null; then
+        type msg_ok >/dev/null 2>&1 \
+            && msg_ok "$(translate 'ProxMenux Monitor unit repaired and restarted')" \
+            || echo "[ProxMenux] Monitor unit repaired and restarted"
+    fi
+}
+
 # ── Check for updates ──────────────────────────────────────
 check_updates() {
     if is_beta; then
@@ -127,5 +191,6 @@ main_menu() {
 
 load_language
 initialize_cache
+auto_repair_monitor_unit
 check_updates
 main_menu


### PR DESCRIPTION
## Summary

Closes the loop on [#222](https://github.com/MacRimi/ProxMenux/issues/222). Two changes:

1. **`menu` self-heal** — `auto_repair_monitor_unit` runs on every `menu` launch and detects the bug's exact fingerprint (unit `ExecStart` pointing at the bare AppImage AND extracted `AppRun` present on disk). When both match it rewrites the unit, reloads systemd, restarts the service, and prints a single `msg_ok` line. For healthy installs and hosts that never had the Monitor it returns immediately.

2. **Revert the v1.2.2.1 patch release** — PR #223 shipped the installer fix together with a version bump to 1.2.2.1 and a matching CHANGELOG entry. The bump isn't needed: users on v1.2.1 stable updating now pull the corrected installer from main and arrive at v1.2.2 working; broken v1.2.2 users get repaired by the menu self-heal on launch. The only effect of leaving 1.2.2.1 published is forcing every healthy v1.2.2 install through a functionally identical update prompt. Revert `version.txt` to 1.2.2 and drop the v1.2.2.1 CHANGELOG section in EN+ES.

Net result after merge: main keeps the install_proxmenux.sh rewrite (already there from #223), adds the menu self-heal (new), and stays on `version.txt = 1.2.2` with the existing release notes intact.

## Test plan

- [ ] Healthy v1.2.2 install: `menu` returns immediately from self-heal (no log noise), no update prompt.
- [ ] Broken v1.2.2 install (unit `ExecStart` on bare AppImage + `AppRun` on disk): `menu` repairs and restarts automatically before the update prompt.
- [ ] Host that never installed the Monitor: `menu` returns immediately, no log noise.
- [ ] v1.2.1 → main update via menu prompt: lands at v1.2.2 working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)