### PR TITLE
Fix uninstall menu for boolean registry entries

### DIFF
--- a/scripts/post_install/uninstall-tools.sh
+++ b/scripts/post_install/uninstall-tools.sh
@@ -984,7 +984,7 @@ show_uninstall_menu() {
     ensure_tools_json
     migrate_installed_tools
     
-    mapfile -t tools_installed < <(jq -r 'to_entries | map(select(.value==true or .value.installed==true)) | .[].key' "$TOOLS_JSON")
+    mapfile -t tools_installed < <(jq -r 'to_entries | map(select(.value==true or .value.installed?==true)) | .[].key' "$TOOLS_JSON")
     
     if [[ ${#tools_installed[@]} -eq 0 ]]; then
         dialog --backtitle "ProxMenux" --title "ProxMenux" \


### PR DESCRIPTION
## Summary

Use jq's optional accessor when reading versioned install state.

A removed optimization can be stored as a boolean `false`. The current filter then evaluates `.installed` on that boolean, jq exits with `Cannot index boolean with string "installed"`, and the uninstall menu receives no entries.

## Testing

- `bash -n scripts/post_install/uninstall-tools.sh`
- Reproduced the jq error with mixed boolean/object registry values
- Verified the fixed filter returns the active entries from a real registry on Proxmox VE 9.2.5
