### PR TITLE
Fix persistent NIC rules matching Linux bridges

### DIFF
--- a/scripts/global/utils-install-functions.sh
+++ b/scripts/global/utils-install-functions.sh
@@ -278,6 +278,7 @@ $PMX_NIC_LINK_MARKER
 
 [Match]
 MACAddress=$mac
+Kind=!bridge
 
 [Link]
 Name=$iface


### PR DESCRIPTION
## Summary

Add `Kind=!bridge` to generated persistent NIC `.link` rules. A Linux bridge can inherit its uplink MAC, causing a MAC-only rule to match `vmbr0` and attempt to rename it to the physical NIC name (`File exists`).

## Validation

- PVE 9.2.10, systemd 257, ProxMenux 1.2.4
- `eth1g` and `eth25g` select the candidate rules
- `vmbr0` falls back to `99-default.link`
- `bash -n` and `git diff --check` pass

Related: #29
