### PR TITLE
fix(post-install): run fwbr udev rule after systemd

### DIFF
--- a/AppImage/scripts/tests/test_fwbr_udev_rule_order.py
+++ b/AppImage/scripts/tests/test_fwbr_udev_rule_order.py
@@ -1,0 +1,49 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+AUTO_POST_INSTALL = REPO_ROOT / "scripts/post_install/auto_post_install.sh"
+CUSTOM_POST_INSTALL = REPO_ROOT / "scripts/post_install/customizable_post_install.sh"
+UNINSTALL_TOOLS = REPO_ROOT / "scripts/post_install/uninstall-tools.sh"
+
+OLD_RULE = "99-proxmenux-fwbr-tune.rules"
+NEW_RULE = "99-zz-proxmenux-fwbr-tune.rules"
+SYSTEMD_RULE = "99-systemd.rules"
+
+
+def network_optimization_block(path: Path) -> str:
+    source = path.read_text()
+    start = source.index("apply_network_optimizations()")
+    end = source.index('register_tool "network_optimization"', start)
+    return source[start:end]
+
+
+class FwbrUdevRuleOrderTests(unittest.TestCase):
+    def test_new_rule_sorts_after_systemd_rule(self):
+        self.assertGreater(NEW_RULE, SYSTEMD_RULE)
+
+    def test_auto_post_install_uses_late_rule_and_removes_legacy_rule(self):
+        source = network_optimization_block(AUTO_POST_INSTALL)
+        self.assertIn('local FUNC_VERSION="1.2"', source)
+        self.assertIn(f"rm -f /etc/udev/rules.d/{OLD_RULE}", source)
+        self.assertIn(f"cat > /etc/udev/rules.d/{NEW_RULE}", source)
+        self.assertIn(f"chmod 0644 /etc/udev/rules.d/{NEW_RULE}", source)
+        self.assertNotIn(f"cat > /etc/udev/rules.d/{OLD_RULE}", source)
+
+    def test_customizable_post_install_uses_late_rule_and_removes_legacy_rule(self):
+        source = network_optimization_block(CUSTOM_POST_INSTALL)
+        self.assertIn('local FUNC_VERSION="1.2"', source)
+        self.assertIn(f"rm -f /etc/udev/rules.d/{OLD_RULE}", source)
+        self.assertIn(f"cat > /etc/udev/rules.d/{NEW_RULE}", source)
+        self.assertIn(f"chmod 0644 /etc/udev/rules.d/{NEW_RULE}", source)
+        self.assertNotIn(f"cat > /etc/udev/rules.d/{OLD_RULE}", source)
+
+    def test_uninstall_removes_new_and_legacy_rule_names(self):
+        source = UNINSTALL_TOOLS.read_text()
+        self.assertIn(f"/etc/udev/rules.d/{OLD_RULE}", source)
+        self.assertIn(f"/etc/udev/rules.d/{NEW_RULE}", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/post_install/auto_post_install.sh
+++ b/scripts/post_install/auto_post_install.sh
@@ -497,7 +497,7 @@ force_apt_ipv4() {
 # ==========================================================
 
 apply_network_optimizations() {
-  local FUNC_VERSION="1.1"
+  local FUNC_VERSION="1.2"
   # description: Tune TCP buffers, somaxconn, IPv4 hardening and disable rp_filter on fw bridges (PVE 9 compatible).
   msg_info "$(translate "Optimizing network settings...")"
   NECESSARY_REBOOT=1
@@ -594,14 +594,16 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 EOF
 
-  cat > /etc/udev/rules.d/99-proxmenux-fwbr-tune.rules <<'EOF'
+  rm -f /etc/udev/rules.d/99-proxmenux-fwbr-tune.rules
+
+  cat > /etc/udev/rules.d/99-zz-proxmenux-fwbr-tune.rules <<'EOF'
 ACTION=="add", SUBSYSTEM=="net", KERNEL=="fwbr*", RUN+="/usr/local/sbin/proxmenux-fwbr-tune %k"
 ACTION=="add", SUBSYSTEM=="net", KERNEL=="fwln*", RUN+="/usr/local/sbin/proxmenux-fwbr-tune %k"
 ACTION=="add", SUBSYSTEM=="net", KERNEL=="fwpr*", RUN+="/usr/local/sbin/proxmenux-fwbr-tune %k"
 ACTION=="add", SUBSYSTEM=="net", KERNEL=="tap*",  RUN+="/usr/local/sbin/proxmenux-fwbr-tune %k"
 EOF
-  chmod 0644 /etc/udev/rules.d/99-proxmenux-fwbr-tune.rules
-  chown root:root /etc/udev/rules.d/99-proxmenux-fwbr-tune.rules
+  chmod 0644 /etc/udev/rules.d/99-zz-proxmenux-fwbr-tune.rules
+  chown root:root /etc/udev/rules.d/99-zz-proxmenux-fwbr-tune.rules
 
   systemctl daemon-reload >/dev/null 2>&1 || true
   udevadm control --reload-rules >/dev/null 2>&1 || true

--- a/scripts/post_install/customizable_post_install.sh
+++ b/scripts/post_install/customizable_post_install.sh
@@ -778,7 +778,7 @@ force_apt_ipv4() {
 
 
 apply_network_optimizations() {
-    local FUNC_VERSION="1.1"
+    local FUNC_VERSION="1.2"
     # description: Tune TCP buffers, somaxconn, IPv4 hardening and disable rp_filter on fw bridges (PVE 9 compatible).
     msg_info "$(translate "Optimizing network settings...")"
     NECESSARY_REBOOT=1
@@ -885,14 +885,16 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 EOF
 
-    cat > /etc/udev/rules.d/99-proxmenux-fwbr-tune.rules <<'EOF'
+    rm -f /etc/udev/rules.d/99-proxmenux-fwbr-tune.rules
+
+    cat > /etc/udev/rules.d/99-zz-proxmenux-fwbr-tune.rules <<'EOF'
 ACTION=="add", SUBSYSTEM=="net", KERNEL=="fwbr*", RUN+="/usr/local/sbin/proxmenux-fwbr-tune %k"
 ACTION=="add", SUBSYSTEM=="net", KERNEL=="fwln*", RUN+="/usr/local/sbin/proxmenux-fwbr-tune %k"
 ACTION=="add", SUBSYSTEM=="net", KERNEL=="fwpr*", RUN+="/usr/local/sbin/proxmenux-fwbr-tune %k"
 ACTION=="add", SUBSYSTEM=="net", KERNEL=="tap*",  RUN+="/usr/local/sbin/proxmenux-fwbr-tune %k"
 EOF
-    chmod 0644 /etc/udev/rules.d/99-proxmenux-fwbr-tune.rules
-    chown root:root /etc/udev/rules.d/99-proxmenux-fwbr-tune.rules
+    chmod 0644 /etc/udev/rules.d/99-zz-proxmenux-fwbr-tune.rules
+    chown root:root /etc/udev/rules.d/99-zz-proxmenux-fwbr-tune.rules
 
     systemctl daemon-reload >/dev/null 2>&1 || true
     udevadm control --reload-rules >/dev/null 2>&1 || true

--- a/scripts/post_install/uninstall-tools.sh
+++ b/scripts/post_install/uninstall-tools.sh
@@ -456,7 +456,8 @@ uninstall_network_optimization() {
     systemctl disable --now proxmenux-fwbr-tune.service >/dev/null 2>&1 || true
     rm -f /etc/systemd/system/proxmenux-fwbr-tune.service
     rm -f /usr/local/sbin/proxmenux-fwbr-tune
-    rm -f /etc/udev/rules.d/99-proxmenux-fwbr-tune.rules
+    rm -f /etc/udev/rules.d/99-proxmenux-fwbr-tune.rules \
+        /etc/udev/rules.d/99-zz-proxmenux-fwbr-tune.rules
     udevadm control --reload-rules >/dev/null 2>&1 || true
 
     systemctl daemon-reload >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- install the fwbr tuning udev rule as `99-zz-proxmenux-fwbr-tune.rules` so it sorts after `99-systemd.rules`
- remove the legacy `99-proxmenux-fwbr-tune.rules` during re-run/upgrade
- cover both legacy and new rule names in uninstall
- bump network optimization `FUNC_VERSION` to `1.2` so existing installs re-apply the fix
- add a regression test for rule ordering and uninstall coverage

Fixes #256.

## Testing
- `bash -n scripts/post_install/auto_post_install.sh scripts/post_install/customizable_post_install.sh scripts/post_install/uninstall-tools.sh`
- `python3 -m unittest AppImage/scripts/tests/test_fwbr_udev_rule_order.py`
- `python3 -m unittest discover -s AppImage/scripts/tests` passed earlier locally, 29 tests total; only the existing optional `pyotp/segno` warning appeared
- End-to-end checked on PVE 9.2.10 / systemd 257 test host:
  - old rule ordering reproduced final `rp_filter=2` after `systemd-sysctl`
  - new `99-zz-proxmenux-fwbr-tune.rules` ordering left final `rp_filter=0` and `log_martians=0`
  - temporary test interfaces/helper/rules were cleaned up afterward