### PR TITLE
i18n: polish Slovak labels and locale parity

### DIFF
--- a/AppImage/messages/de/common.json
+++ b/AppImage/messages/de/common.json
@@ -3522,6 +3522,7 @@
       "deletePbsDescription": "Dadurch wird der PBS-Snapshot aus dem Datenspeicher entfernt.",
       "deletePbsTitle": "PBS-Snapshot löschen",
       "companionFile": "Begleitdatei",
+      "descriptionAfter": "",
       "descriptionBefore": "Durchsuchen Sie die gefundenen Backups und stellen Sie sie wieder her",
       "downloadTitle": "Laden Sie dieses Backup herunter",
       "emptyAfter": "Backups noch nicht.",

--- a/AppImage/messages/es/common.json
+++ b/AppImage/messages/es/common.json
@@ -3522,6 +3522,7 @@
       "deletePbsDescription": "Esto elimina la instantánea de PBS del almacén de datos.",
       "deletePbsTitle": "Eliminar instantánea de PBS",
       "companionFile": "archivo complementario",
+      "descriptionAfter": "",
       "descriptionBefore": "Explorar y restaurar copias de seguridad encontradas en",
       "downloadTitle": "Descarga esta copia de seguridad",
       "emptyAfter": "copias de seguridad todavía.",

--- a/AppImage/messages/fr/common.json
+++ b/AppImage/messages/fr/common.json
@@ -3522,6 +3522,7 @@
       "deletePbsDescription": "Cela supprime l'instantané PBS de la banque de données.",
       "deletePbsTitle": "Supprimer l'instantané PBS",
       "companionFile": "fichier compagnon",
+      "descriptionAfter": "",
       "descriptionBefore": "Parcourez et restaurez les sauvegardes trouvées dans",
       "downloadTitle": "Téléchargez cette sauvegarde",
       "emptyAfter": "sauvegardes encore.",

--- a/AppImage/messages/it/common.json
+++ b/AppImage/messages/it/common.json
@@ -3522,6 +3522,7 @@
       "deletePbsDescription": "Ciò rimuove lo snapshot PBS dall'archivio dati.",
       "deletePbsTitle": "Elimina istantanea PBS",
       "companionFile": "file compagno",
+      "descriptionAfter": "",
       "descriptionBefore": "Sfoglia e ripristina i backup trovati in",
       "downloadTitle": "Scarica questo backup",
       "emptyAfter": "backup ancora.",

--- a/AppImage/messages/pt/common.json
+++ b/AppImage/messages/pt/common.json
@@ -3522,6 +3522,7 @@
       "deletePbsDescription": "Isso remove o instantâneo do PBS do armazenamento de dados.",
       "deletePbsTitle": "Excluir instantâneo do PBS",
       "companionFile": "arquivo complementar",
+      "descriptionAfter": "",
       "descriptionBefore": "Procure e restaure backups encontrados em",
       "downloadTitle": "Baixe este backup",
       "emptyAfter": "backups ainda.",

--- a/AppImage/messages/sk/common.json
+++ b/AppImage/messages/sk/common.json
@@ -1,7 +1,7 @@
 {
   "app": {
     "title": "ProxMenux Monitor",
-    "description": "Proxmox System Dashboard",
+    "description": "Systémový prehľad Proxmoxu",
     "loading": "Načítava sa...",
     "connecting": "Pripájam sa k ProxMenux Monitoru",
     "unknown": "Neznáme",
@@ -143,7 +143,7 @@
       "year": "1 rok"
     },
     "stats": {
-      "avg": "avg",
+      "avg": "priemer",
       "max": "max",
       "min": "min"
     },
@@ -839,7 +839,7 @@
       "topCount": "Prvých {shown} z {total} procesov",
       "loadFailed": "Nepodarilo sa načítať procesy",
       "lifetimeAverageTitle": "Priemerné CPU % za celý život procesu - užitočné pri hľadaní procesov, ktoré dlho bežia potichu na pozadí",
-      "averageShort": "avg"
+      "averageShort": "priem."
     },
     "processInfo": {
       "titleFallback": "Proces",
@@ -4208,7 +4208,7 @@
     "title": "Stav systému",
     "description": "Podrobná kontrola všetkých častí systému",
     "status": {
-      "ok": "OK",
+      "ok": "V poriadku",
       "info": "Info",
       "warning": "Upozornenie",
       "critical": "Problém",
@@ -4218,7 +4218,7 @@
       "total": "Spolu",
       "healthy": "V poriadku",
       "info": "Info",
-      "warning": "Upozornenie",
+      "warning": "Upozornenia",
       "critical": "Problémy",
       "unknown": "Neznáme"
     },


### PR DESCRIPTION
## Summary
- restore a few Slovak labels that regressed to English/short English forms after the broader locale bootstrap
- keep the health status wording consistent with the reviewed Slovak catalog
- add the empty `backup.archives.descriptionAfter` key to the newly populated AppImage locales so their comparable key parity matches English

Follow-up to the i18n discussion in #277.

## Testing
- validated all AppImage and web locale JSON files parse successfully
- checked comparable AppImage key parity across en, de, es, fr, it, pt, sk, sv: 3903 keys each, missing=0, extra=0
- `npm run build` in `AppImage` completed successfully
- deployed the built web output to the PVE test host on port 8008 and verified:
  - `proxmenux-monitor.service` active
  - main page returned HTTP 200
  - protected health endpoint returned expected HTTP 401 without login
- visually checked Slovak labels and Spanish Backup page in the browser; no raw translation key appeared