### PR TITLE
docs(i18n): translate Slovak VM/LXC app docs

### DIFF
--- a/web/messages/sk/docs/monitor/dashboard/vms-lxcs-app.json
+++ b/web/messages/sk/docs/monitor/dashboard/vms-lxcs-app.json
@@ -1,198 +1,198 @@
 {
   "meta": {
-    "title": "App — register and monitor LXC applications | ProxMenux",
-    "description": "Declare the apps running inside an LXC container from the ProxMenux Monitor and optionally track their versions."
+    "title": "App — registrácia a sledovanie aplikácií v LXC | ProxMenux",
+    "description": "Zapíšte aplikácie bežiace v LXC kontajneri cez ProxMenux Monitor a voliteľne sledujte ich verzie."
   },
   "header": {
-    "title": "App — register and monitor LXC applications",
-    "description": "Declare the apps running inside a container, wire quick web links, and optionally track installed vs. upstream versions."
+    "title": "App — registrácia a sledovanie aplikácií v LXC",
+    "description": "Zapíšte aplikácie bežiace v kontajneri, pridajte rýchle webové odkazy a voliteľne sledujte nainštalovanú a najnovšiu verziu."
   },
   "intro": {
-    "p1": "The <strong>App</strong> tab records which applications run inside an LXC container. Each registered app can expose a display name, an icon, one or several web links and — optionally — its version status.",
-    "p2": "A single LXC can host several registered applications. A main service can share the container with an administration interface, an API or any other application reachable on a different port.",
-    "p3": "Registering an application does not modify it or update it. This tab is about identification and display. The mechanisms that <em>execute</em> an update are configured and used from the <link>Updates tab</link>."
+    "p1": "Záložka <strong>App</strong> ukladá informácie o aplikáciách, ktoré bežia v LXC kontajneri. Každá registrovaná aplikácia môže mať zobrazený názov, ikonu, jeden alebo viac webových odkazov a voliteľne aj stav verzie.",
+    "p2": "Jeden LXC môže obsahovať viac registrovaných aplikácií. Hlavná služba môže zdieľať kontajner s administračným rozhraním, API alebo inou aplikáciou dostupnou na inom porte.",
+    "p3": "Registrácia aplikáciu nemení ani neaktualizuje. Táto záložka slúži na pomenovanie, zobrazenie a sledovanie. Mechanizmy, ktoré aktualizáciu skutočne <em>spúšťajú</em>, sa nastavujú a používajú v <link>záložke Aktualizácie</link>."
   },
   "whatYouGet": {
-    "heading": "What you get by registering an app",
-    "lead": "Depending on the data configured, ProxMenux can surface:",
+    "heading": "Čo získate registráciou aplikácie",
+    "lead": "Podľa nastavených údajov vie ProxMenux zobraziť:",
     "items": [
-      "A one-click shortcut to the application's web UI.",
-      "Multiple links when the LXC exposes more than one service or port.",
-      "The version currently installed.",
-      "The latest version published by the project.",
-      "A notice when a newer version is available.",
-      "Notifications on new releases if enabled in Monitor settings."
+      "Skratku jedným kliknutím do webového rozhrania aplikácie.",
+      "Viac odkazov, ak LXC poskytuje viac služieb alebo portov.",
+      "Aktuálne nainštalovanú verziu.",
+      "Najnovšiu verziu vydanú projektom.",
+      "Upozornenie, keď je dostupná novšia verzia.",
+      "Notifikácie o nových vydaniach, ak sú povolené v nastaveniach Monitoru."
     ],
-    "trailing": "Version tracking is optional. An app can be registered purely to keep its name, icon and web links handy.",
-    "callout": "The <strong>Update available</strong> label means ProxMenux found a difference between the installed and the published version. It does not automatically mean it also knows how to upgrade the app — that is a separate setup, done on the Updates tab."
+    "trailing": "Sledovanie verzie je voliteľné. Aplikáciu môžete zaregistrovať aj len preto, aby ste mali poruke jej názov, ikonu a webové odkazy.",
+    "callout": "Štítok <strong>Dostupná aktualizácia</strong> znamená, že ProxMenux našiel rozdiel medzi nainštalovanou a vydanou verziou. Neznamená to automaticky, že vie aplikáciu aj aktualizovať — to je samostatné nastavenie v záložke Aktualizácie."
   },
   "firstOpening": {
-    "heading": "First time opening the App tab",
-    "p1": "On first open, ProxMenux tries to recognise apps in the container using the information it has: the installer used when the LXC was created, detected services, and ports that are listening.",
-    "p2": "When matches are found, they show up as suggestions. Always review the proposal before saving — auto-detection speeds up registration, but it cannot guarantee that every detected service corresponds exactly to the app you intended."
+    "heading": "Prvé otvorenie záložky App",
+    "p1": "Pri prvom otvorení sa ProxMenux pokúsi rozpoznať aplikácie v kontajneri podľa dostupných informácií: inštalátora použitého pri vytvorení LXC, nájdených služieb a otvorených portov.",
+    "p2": "Ak nájde zhodu, zobrazí ju ako návrh. Pred uložením návrh vždy skontrolujte — automatická detekcia registráciu zrýchli, ale nevie zaručiť, že každá nájdená služba presne zodpovedá aplikácii, ktorú chcete zapísať."
   },
   "figures": {
     "f01": {
-      "alt": "Empty App tab showing detected app suggestions",
-      "caption": "Empty state with one or more detected suggestions"
+      "alt": "Prázdna záložka App so zobrazenými návrhmi nájdených aplikácií",
+      "caption": "Prázdny stav s jedným alebo viacerými nájdenými návrhmi"
     },
     "f02": {
-      "alt": "Catalog search showing matches for the typed name",
-      "caption": "Catalog search and match selection"
+      "alt": "Vyhľadávanie v katalógu so zhodami podľa zadaného názvu",
+      "caption": "Vyhľadávanie v katalógu a výber zhody"
     },
     "f03": {
-      "alt": "App registration form with name, icon and two web links",
-      "caption": "Basic form with name, icon and two web links"
+      "alt": "Formulár registrácie aplikácie s názvom, ikonou a dvoma webovými odkazmi",
+      "caption": "Základný formulár s názvom, ikonou a dvoma webovými odkazmi"
     },
     "f04": {
-      "alt": "LXC with Docmost and Redis both registered as separate apps, each with its own version state",
-      "caption": "Two apps in the same LXC — a file-tracked app and a dpkg-tracked one, each with its own version state"
+      "alt": "LXC s aplikáciami Docmost a Redis zaregistrovanými samostatne, každá s vlastným stavom verzie",
+      "caption": "Dve aplikácie v rovnakom LXC — jedna sleduje verziu zo súboru, druhá cez dpkg, každá má vlastný stav verzie"
     },
     "f05": {
-      "alt": "Advanced tracking options showing the installed-version method and the upstream source",
-      "caption": "Advanced options with the installed-version method and the upstream source"
+      "alt": "Pokročilé možnosti sledovania s metódou nainštalovanej verzie a zdrojom najnovšej verzie",
+      "caption": "Pokročilé možnosti s metódou nainštalovanej verzie a zdrojom najnovšej verzie"
     },
     "f06": {
-      "alt": "Registered app card with the installed version, the latest upstream version and an Update available indicator",
-      "caption": "A wired card shows Installed, Latest upstream, an Update-available arrow when they differ, and the web link"
+      "alt": "Karta registrovanej aplikácie s nainštalovanou verziou, najnovšou upstream verziou a indikátorom dostupnej aktualizácie",
+      "caption": "Nastavená karta zobrazuje Nainštalované, Najnovšia upstream, šípku dostupnej aktualizácie pri rozdiele verzií a webový odkaz"
     },
     "f07": {
-      "alt": "Minimal registered app showing just its name and a single web link, no version tracking",
-      "caption": "Link-only record — just a name and a web link, without version tracking"
+      "alt": "Minimálna registrovaná aplikácia iba s názvom a jedným webovým odkazom, bez sledovania verzie",
+      "caption": "Záznam iba s odkazom — len názov a webový odkaz, bez sledovania verzie"
     }
   },
   "registerSuggested": {
-    "heading": "Registering a suggested app",
+    "heading": "Registrácia navrhnutej aplikácie",
     "steps": [
-      "Open the LXC from the <strong>VMs & LXCs</strong> card.",
-      "Select the <strong>App</strong> tab.",
-      "Locate the suggested app.",
-      "Press <strong>Register</strong>.",
-      "Check the name, links and auto-filled data.",
-      "Save the app."
+      "Otvorte LXC z karty <strong>VM a LXC</strong>.",
+      "Vyberte záložku <strong>App</strong>.",
+      "Nájdite navrhnutú aplikáciu.",
+      "Kliknite na <strong>Registrovať</strong>.",
+      "Skontrolujte názov, odkazy a automaticky doplnené údaje.",
+      "Uložte aplikáciu."
     ],
-    "trailing": "If a suggestion doesn't match anything you actually want to register, you can hide it. Hidden suggestions can be brought back from <strong>Register a different app</strong>."
+    "trailing": "Ak návrh nezodpovedá ničomu, čo chcete registrovať, môžete ho skryť. Skryté návrhy sa dajú znovu zobraziť cez <strong>Registrovať inú aplikáciu</strong>."
   },
   "catalog": {
-    "heading": "Using the catalog",
-    "p1": "The catalog helps you find known applications and pre-fill some of their data. Typing into the name field shows the closest matches — picking one can autofill the name, icon, typical ports and, when a verified profile exists, the version-tracking options too.",
-    "p2": "The catalog is a helper, not a complete list of every piece of software an LXC might host. Some entries only carry basic information; others also include a ready-made way to read the installed version.",
-    "p3": "If the application isn't in the catalog, register it manually."
+    "heading": "Používanie katalógu",
+    "p1": "Katalóg pomáha nájsť známe aplikácie a predvyplniť časť údajov. Pri písaní do poľa názvu zobrazí najbližšie zhody — výber zhody môže doplniť názov, ikonu, typické porty a pri overenom profile aj možnosti sledovania verzie.",
+    "p2": "Katalóg je pomocník, nie úplný zoznam každého softvéru, ktorý môže LXC obsahovať. Niektoré položky majú iba základné informácie, iné obsahujú aj pripravený spôsob čítania nainštalovanej verzie.",
+    "p3": "Ak aplikácia v katalógu nie je, zaregistrujte ju ručne."
   },
   "manual": {
-    "heading": "Register an application manually",
-    "p1": "Use <strong>Register a different app</strong> when the LXC has no apps yet. If it already has at least one, use <strong>Add another application</strong>.",
-    "p2": "The basic configuration only needs a name. Everything else is added according to what you want to display.",
-    "nameHeading": "Name and icon",
-    "nameBody": "Give the app a name that makes it easy to recognise. The icon is optional and can be supplied as a URL.",
-    "linksHeading": "Web links and ports",
-    "linksLead": "Each link can carry:",
+    "heading": "Ručná registrácia aplikácie",
+    "p1": "Použite <strong>Registrovať inú aplikáciu</strong>, ak LXC ešte nemá žiadne aplikácie. Ak už aspoň jednu má, použite <strong>Pridať ďalšiu aplikáciu</strong>.",
+    "p2": "Základné nastavenie potrebuje iba názov. Všetko ostatné doplníte podľa toho, čo chcete zobrazovať.",
+    "nameHeading": "Názov a ikona",
+    "nameBody": "Zadajte aplikácii názov, podľa ktorého ju ľahko rozpoznáte. Ikona je voliteľná a môže byť zadaná ako URL.",
+    "linksHeading": "Webové odkazy a porty",
+    "linksLead": "Každý odkaz môže obsahovať:",
     "linksItems": [
-      "Protocol <code>http</code> or <code>https</code>.",
+      "Protokol <code>http</code> alebo <code>https</code>.",
       "Port.",
-      "Description, such as <em>Web UI</em>, <em>Administration</em> or <em>API</em>.",
-      "An optional per-link icon."
+      "Popis, napríklad <em>Web UI</em>, <em>Administrácia</em> alebo <em>API</em>.",
+      "Voliteľnú ikonu pre konkrétny odkaz."
     ],
-    "linksTrailing": "ProxMenux combines protocol and port with the LXC's IP address to build the URL. Add as many links as the app needs when a single container exposes several related services.",
-    "linksConfirm": "Before saving, confirm the port really corresponds to the service and that you can reach it from the browser."
+    "linksTrailing": "ProxMenux spojí protokol a port s IP adresou LXC a vytvorí URL. Ak jeden kontajner poskytuje viac súvisiacich služieb, pridajte toľko odkazov, koľko aplikácia potrebuje.",
+    "linksConfirm": "Pred uložením overte, že port naozaj patrí danej službe a že sa naň viete dostať z prehliadača."
   },
   "multiple": {
-    "heading": "Registering several apps in the same LXC",
-    "intro": "After saving the first app, press <strong>Add another application</strong> and repeat. Each record keeps its own links, detection method and version state independently.",
-    "usefulLead": "This is useful when:",
+    "heading": "Registrácia viacerých aplikácií v rovnakom LXC",
+    "intro": "Po uložení prvej aplikácie kliknite na <strong>Pridať ďalšiu aplikáciu</strong> a postup zopakujte. Každý záznam si nezávisle drží vlastné odkazy, metódu detekcie aj stav verzie.",
+    "usefulLead": "Hodí sa to, keď:",
     "usefulItems": [
-      "An LXC hosts several independent services.",
-      "An installation includes a main app plus companion tooling.",
-      "Each service has its own web interface or its own release cycle."
+      "Jeden LXC hostí viac samostatných služieb.",
+      "Inštalácia obsahuje hlavnú aplikáciu aj doplnkové nástroje.",
+      "Každá služba má vlastné webové rozhranie alebo vlastný cyklus vydávania."
     ],
-    "dontGroup": "Don't group under a single record programs that publish and update independently. Registering them separately makes it clear which one has a new release and lets each one carry its own update method on the Updates tab."
+    "dontGroup": "Nespájajte do jedného záznamu programy, ktoré sa vydávajú a aktualizujú samostatne. Oddelená registrácia jasne ukáže, ktorá aplikácia má novú verziu, a každej umožní mať vlastnú metódu aktualizácie v záložke Aktualizácie."
   },
   "tracking": {
-    "heading": "Version tracking",
-    "intro": "Open the advanced options in the form to configure version tracking. Two different pieces of information are needed:",
+    "heading": "Sledovanie verzie",
+    "intro": "Sledovanie verzie nastavíte otvorením pokročilých možností vo formulári. Potrebné sú dve rôzne informácie:",
     "ingredients": [
-      "<strong>Installed version</strong> — how to read the version currently running inside the LXC.",
-      "<strong>Latest available version</strong> — where to read the version published by the project."
+      "<strong>Nainštalovaná verzia</strong> — ako prečítať verziu, ktorá práve beží v LXC.",
+      "<strong>Najnovšia dostupná verzia</strong> — odkiaľ prečítať verziu vydanú projektom."
     ],
-    "trailing": "If only the installed version is configured, ProxMenux can show it, but cannot tell whether an update exists. For an <strong>Update available</strong> label to appear, both values have to be readable and comparable.",
-    "methodsHeading": "Methods to read the installed version",
-    "methodsLead": "Pick the method that matches how the app was installed:",
+    "trailing": "Ak je nastavená iba nainštalovaná verzia, ProxMenux ju vie zobraziť, ale nevie povedať, či existuje aktualizácia. Aby sa zobrazil štítok <strong>Dostupná aktualizácia</strong>, obe hodnoty musia byť čitateľné a porovnateľné.",
+    "methodsHeading": "Metódy čítania nainštalovanej verzie",
+    "methodsLead": "Vyberte metódu podľa toho, ako bola aplikácia nainštalovaná:",
     "methodsTable": {
-      "colMethod": "Method",
-      "colWhen": "When to use it",
+      "colMethod": "Metóda",
+      "colWhen": "Kedy ju použiť",
       "rows": [
-        { "method": "None (link only)", "when": "You only need the name and web links." },
-        { "method": "dpkg package", "when": "The application is installed as a Debian or Ubuntu package." },
-        { "method": "apk package", "when": "The application is installed as an Alpine package." },
-        { "method": "Binary", "when": "An executable returns its version through an argument like --version." },
-        { "method": "File + regex", "when": "The version string is written inside a file." },
-        { "method": "Python distribution", "when": "The application is installed as a Python package." },
-        { "method": "Command", "when": "A specific command must be executed to obtain the version." },
-        { "method": "Manual", "when": "The user enters the installed version by hand." }
+        { "method": "Žiadna (iba odkaz)", "when": "Potrebujete len názov a webové odkazy." },
+        { "method": "dpkg balík", "when": "Aplikácia je nainštalovaná ako Debian alebo Ubuntu balík." },
+        { "method": "apk balík", "when": "Aplikácia je nainštalovaná ako Alpine balík." },
+        { "method": "Binárka", "when": "Spustiteľný súbor vracia verziu cez argument ako --version." },
+        { "method": "Súbor + regex", "when": "Reťazec verzie je zapísaný v súbore." },
+        { "method": "Python distribúcia", "when": "Aplikácia je nainštalovaná ako Python balík." },
+        { "method": "Príkaz", "when": "Na získanie verzie treba spustiť konkrétny príkaz." },
+        { "method": "Ručne", "when": "Používateľ zadá nainštalovanú verziu ručne." }
       ]
     },
-    "methodsTrailing": "Use the most direct and stable method. If the application comes from a system package, prefer querying that package over parsing the output of a generic command.",
-    "commandHeading": "The Command method does not update the app",
-    "commandP1": "In this form, <strong>Command</strong> serves exclusively to read the installed version. Its arguments are entered comma-separated and ProxMenux runs them directly, without a shell interpreter.",
-    "commandP2": "If your usual query is:",
+    "methodsTrailing": "Použite čo najpriamejšiu a najstabilnejšiu metódu. Ak aplikácia pochádza zo systémového balíka, uprednostnite dotaz na balík pred parsovaním výstupu všeobecného príkazu.",
+    "commandHeading": "Metóda Príkaz aplikáciu neaktualizuje",
+    "commandP1": "V tomto formulári slúži <strong>Príkaz</strong> výhradne na prečítanie nainštalovanej verzie. Argumenty sa zadávajú oddelené čiarkou a ProxMenux ich spúšťa priamo, bez shell interpretera.",
+    "commandP2": "Ak je váš bežný dotaz:",
     "commandExample1": "myapp version --short",
-    "commandP3": "Form arguments would be:",
+    "commandP3": "Argumenty vo formulári budú:",
     "commandExample2": "myapp, version, --short",
-    "commandP4": "Don't use operators like <code>&&</code>, redirections or pipes here. If you need a full procedure to upgrade the application, that is configured later on the Updates tab.",
-    "sourceHeading": "Source for the latest available version",
-    "sourceLead": "ProxMenux can query a public source of the project, for example:",
+    "commandP4": "Nepoužívajte tu operátory ako <code>&&</code>, presmerovania ani pipes. Ak potrebujete celý postup na aktualizáciu aplikácie, nastavuje sa neskôr v záložke Aktualizácie.",
+    "sourceHeading": "Zdroj najnovšej dostupnej verzie",
+    "sourceLead": "ProxMenux vie čítať verejný zdroj projektu, napríklad:",
     "sourceItems": [
-      "The releases or tags of a GitHub repository.",
-      "An HTTP endpoint that returns the version inside a JSON response."
+      "Releases alebo tagy GitHub repozitára.",
+      "HTTP endpoint, ktorý vracia verziu v JSON odpovedi."
     ],
-    "sourceTrailing": "Always use the app's official source. A fork or a third-party endpoint may announce versions that don't match the installation in the LXC.",
-    "regexHeading": "Version regular expressions",
-    "regexIntro": "A regular expression, or <strong>regex</strong>, isolates the version number inside a longer text. Most projects don't publish a ready-made regex — the user builds one from real output or a real release name.",
-    "regexOptional": "It is not always needed. Leave it empty first if the source already returns a clean value like <code>2.14.3</code>. Add one only when ProxMenux needs to separate the version from other words, symbols or numbers.",
-    "regexTwoHeading": "There are two different regex fields",
+    "sourceTrailing": "Vždy používajte oficiálny zdroj aplikácie. Fork alebo endpoint tretej strany môže oznamovať verzie, ktoré nezodpovedajú inštalácii v LXC.",
+    "regexHeading": "Regulárne výrazy pre verziu",
+    "regexIntro": "Regulárny výraz, teda <strong>regex</strong>, vytiahne číslo verzie z dlhšieho textu. Väčšina projektov neposkytuje hotový regex — používateľ si ho vytvorí podľa reálneho výstupu alebo skutočného názvu vydania.",
+    "regexOptional": "Nie vždy je potrebný. Najprv ho nechajte prázdny, ak zdroj vracia čistú hodnotu ako <code>2.14.3</code>. Pridajte ho až vtedy, keď ProxMenux potrebuje oddeliť verziu od ďalších slov, symbolov alebo čísel.",
+    "regexTwoHeading": "Existujú dve rôzne regex polia",
     "regexTwoItems": [
-      "<strong>Installed version regex</strong> is applied to the output read inside the LXC.",
-      "<strong>Version regex</strong> or <strong>Tag regex</strong> is applied to the release / tag name published by the external source."
+      "<strong>Regex nainštalovanej verzie</strong> sa použije na výstup prečítaný vo vnútri LXC.",
+      "<strong>Regex verzie</strong> alebo <strong>regex tagu</strong> sa použije na názov release / tagu z externého zdroja."
     ],
-    "regexTwoTrailing": "Both must produce comparable values. For instance, if the local app returns <code>MyApp v2.14.3</code> and GitHub publishes <code>release-2.14.3</code>, both expressions should extract <code>2.14.3</code>.",
-    "step1Heading": "1. Capture a real sample",
-    "step1P1": "Before writing the pattern, capture exactly the text ProxMenux will have to interpret.",
-    "step1P2": "For the installed version, run the same binary and arguments configured in the form from the LXC console. Depending on the method, you may also query the corresponding package or file.",
-    "step1P3": "For example:",
+    "regexTwoTrailing": "Obe hodnoty musia byť porovnateľné. Napríklad ak lokálna aplikácia vráti <code>MyApp v2.14.3</code> a GitHub publikuje <code>release-2.14.3</code>, oba výrazy by mali vytiahnuť <code>2.14.3</code>.",
+    "step1Heading": "1. Zachyťte reálnu ukážku",
+    "step1P1": "Pred písaním vzoru zachyťte presný text, ktorý bude musieť ProxMenux spracovať.",
+    "step1P2": "Pri nainštalovanej verzii spustite rovnakú binárku a argumenty, aké sú nastavené vo formulári, priamo z konzoly LXC. Podľa metódy môžete dotazovať aj príslušný balík alebo súbor.",
+    "step1P3": "Napríklad:",
     "step1Cmd": "myapp --version",
-    "step1P4": "Suppose the real output is:",
+    "step1P4": "Predpokladajme, že reálny výstup je:",
     "step1Output": "MyApp version v2.14.3 (stable)",
-    "step1P5": "For the published version, check the exact release or tag name in the official repository. If you use a JSON endpoint, inspect the value the configured path returns.",
-    "step1P6": "Do not build the pattern against an invented example — a single space, prefix or extra number can change the result.",
-    "step2Heading": "2. Identify the part to keep",
-    "step2Lead": "In the example above we want to keep <code>2.14.3</code> and drop:",
+    "step1P5": "Pri publikovanej verzii skontrolujte presný názov release alebo tagu v oficiálnom repozitári. Ak používate JSON endpoint, pozrite hodnotu, ktorú vracia nastavená cesta.",
+    "step1P6": "Nevytvárajte vzor podľa vymysleného príkladu — jediná medzera, prefix alebo číslo navyše môže zmeniť výsledok.",
+    "step2Heading": "2. Určite časť, ktorú chcete ponechať",
+    "step2Lead": "V príklade vyššie chceme ponechať <code>2.14.3</code> a zahodiť:",
     "step2Items": [
-      "The text <code>MyApp version</code>.",
-      "The letter <code>v</code>.",
-      "The text <code>(stable)</code>."
+      "Text <code>MyApp version</code>.",
+      "Písmeno <code>v</code>.",
+      "Text <code>(stable)</code>."
     ],
-    "step2Recommended": "The recommended expression:",
+    "step2Recommended": "Odporúčaný výraz:",
     "step2Regex": "version[ :=]+v?([0-9]+\\.[0-9]+\\.[0-9]+)",
-    "step2ReadLead": "Read piece by piece:",
+    "step2ReadLead": "Čítané po častiach:",
     "step2Breakdown": {
-      "colPart": "Fragment",
-      "colMeaning": "Meaning",
+      "colPart": "Časť",
+      "colMeaning": "Význam",
       "rows": [
-        { "part": "version", "meaning": "Anchors the search on that word to avoid matching an unrelated number." },
-        { "part": "[ :=]+", "meaning": "Accepts one or more spaces, colons or equal signs." },
-        { "part": "v?", "meaning": "The letter v may appear once or not at all." },
-        { "part": "( and )", "meaning": "Mark the portion ProxMenux should keep." },
-        { "part": "[0-9]+", "meaning": "Matches one or more digits." },
-        { "part": "\\.", "meaning": "Matches a literal dot between the numbers." }
+        { "part": "version", "meaning": "Ukotví hľadanie na tomto slove, aby sa nezhodovalo nesúvisiace číslo." },
+        { "part": "[ :=]+", "meaning": "Povolí jednu alebo viac medzier, dvojbodiek alebo znamienok rovnosti." },
+        { "part": "v?", "meaning": "Písmeno v sa môže objaviť raz alebo vôbec." },
+        { "part": "( and )", "meaning": "Označuje časť, ktorú má ProxMenux ponechať." },
+        { "part": "[0-9]+", "meaning": "Zodpovedá jednej alebo viacerým čísliciam." },
+        { "part": "\\.", "meaning": "Zodpovedá skutočnej bodke medzi číslami." }
       ]
     },
-    "step2DotNote": "The dot is written as <code>\\.</code> because, in a regex, a bare dot means \"any character\".",
-    "step3Heading": "3. Pick a pattern that fits the format",
-    "step3Lead": "These patterns cover the most common cases:",
+    "step2DotNote": "Bodka sa píše ako <code>\\.</code>, pretože samotná bodka v regexe znamená „ľubovoľný znak“.",
+    "step3Heading": "3. Vyberte vzor podľa formátu",
+    "step3Lead": "Tieto vzory pokrývajú najčastejšie prípady:",
     "step3Examples": {
-      "colText": "Sample text",
-      "colRegex": "Recommended regex",
-      "colResult": "Result",
+      "colText": "Ukážkový text",
+      "colRegex": "Odporúčaný regex",
+      "colResult": "Výsledok",
       "rows": [
         { "text": "v2.14.3", "regex": "v?([0-9]+\\.[0-9]+\\.[0-9]+)", "result": "2.14.3" },
         { "text": "Version: 2.14", "regex": "Version[ :=]+v?([0-9]+(?:\\.[0-9]+){1,3})", "result": "2.14" },
@@ -201,72 +201,72 @@
         { "text": "{\"version\":\"2.14.3\"}", "regex": "\"version\"\\s*:\\s*\"v?([0-9]+(?:\\.[0-9]+){1,3})\"", "result": "2.14.3" }
       ]
     },
-    "step3Note1": "<code>(?: ... )</code> groups a fragment of the pattern without producing an extra output value. This form is convenient to accept versions with two, three or four blocks without complicating the result.",
-    "step3Note2": "Enter the regex exactly as shown in the table: without surrounding quotes and without the <code>/.../</code> delimiters some online tools use.",
-    "step4Heading": "4. Prefer a single capture",
-    "step4Intro": "ProxMenux uses capture groups to decide which value to return:",
+    "step3Note1": "<code>(?: ... )</code> zoskupí časť vzoru bez vytvorenia ďalšej výstupnej hodnoty. Hodí sa na prijatie verzií s dvoma, tromi alebo štyrmi blokmi bez komplikovania výsledku.",
+    "step3Note2": "Regex zadajte presne ako v tabuľke: bez úvodzoviek okolo a bez oddeľovačov <code>/.../</code>, ktoré používajú niektoré online nástroje.",
+    "step4Heading": "4. Uprednostnite jednu zachytávaciu skupinu",
+    "step4Intro": "ProxMenux používa zachytávacie skupiny na rozhodnutie, ktorú hodnotu vráti:",
     "step4Items": [
-      "With no capture groups it keeps the whole match.",
-      "With one capture, it keeps that capture's content.",
-      "With several captures, it joins them with dots."
+      "Bez zachytávacích skupín ponechá celú zhodu.",
+      "S jednou skupinou ponechá obsah tejto skupiny.",
+      "S viacerými skupinami ich spojí bodkami."
     ],
-    "step4Trailing": "For predictable results, wrap the whole version in a single capture and use <code>(?: ... )</code> for helper groups.",
-    "step4RecLabel": "Recommended:",
+    "step4Trailing": "Pre predvídateľný výsledok obaľte celú verziu do jednej skupiny a pomocné skupiny zapisujte ako <code>(?: ... )</code>.",
+    "step4RecLabel": "Odporúčané:",
     "step4RecRegex": "v?([0-9]+(?:\\.[0-9]+){1,3})",
-    "step4LessLabel": "Less clear for beginners:",
+    "step4LessLabel": "Menej jasné pre začiatočníkov:",
     "step4LessRegex": "v?([0-9]+)\\.([0-9]+)\\.([0-9]+)",
-    "step4Note": "Both can produce <code>2.14.3</code>, but the first is easier to maintain if the format changes.",
-    "step5Heading": "5. Avoid overly broad matches",
-    "step5Lead": "A pattern like this one is usually too open:",
+    "step4Note": "Oba výrazy môžu vytvoriť <code>2.14.3</code>, ale prvý sa ľahšie udržiava, ak sa formát zmení.",
+    "step5Heading": "5. Vyhnite sa príliš širokým zhodám",
+    "step5Lead": "Takýto vzor býva zvyčajne príliš voľný:",
     "step5Regex": "([0-9.]+)",
-    "step5P1": "It can capture a year, a port, a dependency version or the first number that appears in the output. Anchor it with a nearby word such as <code>version</code>, <code>release</code> or <code>build</code> when the text carries several numbers.",
-    "step5P2": "Also confirm the upstream source isn't mixing stable releases with beta, nightly or development builds. The regex must select the same channel that is installed in the LXC.",
-    "step6Heading": "6. Save and verify the result",
-    "step6Lead": "After saving the app, press <strong>Check</strong> and read the two values ProxMenux reports:",
-    "step6Output": "Installed: 2.14.3\nLatest:    2.15.0",
-    "step6CorrectLead": "The regex is correct when:",
+    "step5P1": "Môže zachytiť rok, port, verziu závislosti alebo prvé číslo, ktoré sa vo výstupe objaví. Ak text obsahuje viac čísel, ukotvite ho blízkym slovom ako <code>version</code>, <code>release</code> alebo <code>build</code>.",
+    "step5P2": "Overte aj to, že upstream zdroj nemieša stabilné vydania s beta, nightly alebo vývojovými buildmi. Regex musí vybrať rovnaký kanál, aký je nainštalovaný v LXC.",
+    "step6Heading": "6. Uložte a overte výsledok",
+    "step6Lead": "Po uložení aplikácie kliknite na <strong>Skontrolovať</strong> a pozrite si dve hodnoty, ktoré ProxMenux zobrazí:",
+    "step6Output": "Nainštalované: 2.14.3\nNajnovšia:     2.15.0",
+    "step6CorrectLead": "Regex je správny, keď:",
     "step6CorrectItems": [
-      "Both fields contain only the expected version.",
-      "The application name and extra text are not captured.",
-      "The version is not confused with any other number.",
-      "Local and published values use the same format."
+      "Obe polia obsahujú iba očakávanú verziu.",
+      "Názov aplikácie ani ďalší text nie sú zachytené.",
+      "Verzia nie je zamenená s iným číslom.",
+      "Lokálna aj publikovaná hodnota používajú rovnaký formát."
     ],
-    "step6ErrorNote": "If the match errors out, capture the real output again and compare it character by character. Pay particular attention to uppercase, spaces, hyphens, the letter <code>v</code> and the number of version blocks.",
-    "step6Callout": "If you can't build a reliable pattern, prefer to disable upstream tracking temporarily and keep the app as a link-only record. A wrong regex can raise false alerts or hide a real update."
+    "step6ErrorNote": "Ak zhoda skončí chybou, znovu zachyťte reálny výstup a porovnajte ho znak po znaku. Pozor najmä na veľké písmená, medzery, pomlčky, písmeno <code>v</code> a počet blokov verzie.",
+    "step6Callout": "Ak neviete vytvoriť spoľahlivý vzor, radšej dočasne vypnite upstream sledovanie a nechajte aplikáciu ako záznam iba s odkazom. Nesprávny regex môže vytvárať falošné upozornenia alebo skryť reálnu aktualizáciu."
   },
   "state": {
-    "heading": "Reading an app's state",
-    "lead": "A registered app can display any of the following states:",
+    "heading": "Čítanie stavu aplikácie",
+    "lead": "Registrovaná aplikácia môže zobraziť niektorý z týchto stavov:",
     "items": [
-      "<strong>Up to date</strong> — versions match.",
-      "<strong>Update available</strong> — the source publishes a newer version.",
-      "<strong>Checking</strong> — the check is in progress.",
-      "<strong>Version tracking pending</strong> — no check has completed yet.",
-      "<strong>Error</strong> — one of the versions could not be read or parsed."
+      "<strong>Aktuálne</strong> — verzie sa zhodujú.",
+      "<strong>Dostupná aktualizácia</strong> — zdroj publikuje novšiu verziu.",
+      "<strong>Kontroluje sa</strong> — kontrola práve prebieha.",
+      "<strong>Sledovanie verzie čaká</strong> — ešte neprebehla žiadna kontrola.",
+      "<strong>Chyba</strong> — jednu z verzií sa nepodarilo prečítať alebo spracovať."
     ],
-    "trailing": "Use <strong>Check</strong> to repeat the query manually after tweaking the configuration. If an error appears, review the installed-version method, the upstream source and the regex patterns first."
+    "trailing": "Po úprave nastavení použite <strong>Skontrolovať</strong> na opakovanie dotazu. Ak sa zobrazí chyba, najprv skontrolujte metódu nainštalovanej verzie, upstream zdroj a regex vzory."
   },
   "manage": {
-    "heading": "Managing existing records",
-    "lead": "Enter management mode to:",
+    "heading": "Správa existujúcich záznamov",
+    "lead": "V režime správy môžete:",
     "items": [
-      "Re-check an app.",
-      "Edit its name, links or version tracking.",
-      "Delete a record that is no longer needed.",
-      "Add another app to the same LXC."
+      "Znovu skontrolovať aplikáciu.",
+      "Upraviť jej názov, odkazy alebo sledovanie verzie.",
+      "Odstrániť záznam, ktorý už nepotrebujete.",
+      "Pridať ďalšiu aplikáciu do rovnakého LXC."
     ],
-    "trailing": "Deleting a record does not uninstall or stop the app. It only removes the information ProxMenux uses to display it and monitor its version."
+    "trailing": "Odstránenie záznamu aplikáciu neodinštaluje ani nezastaví. Odstráni iba informácie, ktoré ProxMenux používa na jej zobrazenie a sledovanie verzie."
   },
   "notDetected": {
-    "heading": "If the app is not detected",
-    "intro": "Automatic detection is not required to use this feature. If no suggestion appears:",
+    "heading": "Ak aplikácia nebola nájdená",
+    "intro": "Automatická detekcia nie je nutná na používanie tejto funkcie. Ak sa nezobrazí žiadny návrh:",
     "steps": [
-      "Register the app manually.",
-      "Add its known links and ports.",
-      "Leave it as <strong>None (link only)</strong> if you only need a shortcut.",
-      "Configure version tracking only when a reliable source has been identified for both values.",
-      "Configure the update method later from <link>Updates</link>, if you want ProxMenux to run it."
+      "Zaregistrujte aplikáciu ručne.",
+      "Pridajte jej známe odkazy a porty.",
+      "Nechajte ju ako <strong>Žiadna (iba odkaz)</strong>, ak potrebujete iba skratku.",
+      "Sledovanie verzie nastavte až vtedy, keď máte pre obe hodnoty spoľahlivý zdroj.",
+      "Metódu aktualizácie nastavte neskôr cez <link>Aktualizácie</link>, ak chcete, aby ju ProxMenux spúšťal."
     ],
-    "trailing": "Don't invent a package name, path or regex just to fill the form. A simple, correct record beats an automatic tracking based on unverified data."
+    "trailing": "Nevymýšľajte názov balíka, cestu ani regex len preto, aby bol formulár vyplnený. Jednoduchý a správny záznam je lepší než automatické sledovanie postavené na neoverených údajoch."
   }
 }

--- a/web/messages/sk/docs/monitor/dashboard/vms-lxcs-updates.json
+++ b/web/messages/sk/docs/monitor/dashboard/vms-lxcs-updates.json
@@ -1,231 +1,231 @@
 {
   "meta": {
-    "title": "Updates — updating an LXC's system and apps | ProxMenux",
-    "description": "Which mechanisms ProxMenux can use to update the operating system and the applications registered in an LXC container."
+    "title": "Aktualizácie — aktualizácia systému a aplikácií v LXC | ProxMenux",
+    "description": "Mechanizmy, ktoré vie ProxMenux použiť na aktualizáciu operačného systému a aplikácií registrovaných v LXC kontajneri."
   },
   "header": {
-    "title": "Updates — updating an LXC's system and apps",
-    "description": "Where ProxMenux decides how to upgrade a container: OS packages, Community Scripts helper, or a custom command."
+    "title": "Aktualizácie — aktualizácia systému a aplikácií v LXC",
+    "description": "Miesto, kde ProxMenux rozhoduje, ako aktualizovať kontajner: systémové balíky, pomocník Community Scripts alebo vlastný príkaz."
   },
   "intro": {
-    "p1": "The <strong>Updates</strong> tab gathers the mechanisms ProxMenux can run to upgrade the operating system and the applications registered inside an LXC container.",
-    "p2": "The <link>App tab</link> declares which applications exist and, optionally, compares their versions. <strong>Updates</strong> is about the action: it decides which mechanism is available, presents the matching button and runs the upgrade inside the container.",
-    "callout": "<strong>Core idea:</strong> detecting a new version and knowing how to install it are two different jobs. An app can show <strong>Update available</strong> on the App tab and still not have a working update button until a valid method is defined."
+    "p1": "Záložka <strong>Aktualizácie</strong> zhromažďuje mechanizmy, ktoré vie ProxMenux spustiť na aktualizáciu operačného systému a aplikácií registrovaných vo vnútri LXC kontajnera.",
+    "p2": "<link>Záložka App</link> určuje, ktoré aplikácie existujú, a voliteľne porovnáva ich verzie. <strong>Aktualizácie</strong> riešia samotnú akciu: rozhodnú, ktorý mechanizmus je dostupný, zobrazia príslušné tlačidlo a spustia aktualizáciu v kontajneri.",
+    "callout": "<strong>Základná myšlienka:</strong> zistenie novej verzie a znalosť spôsobu jej inštalácie sú dve rozdielne veci. Aplikácia môže v záložke App ukazovať <strong>Dostupná aktualizácia</strong>, ale stále nemusí mať funkčné tlačidlo na aktualizáciu, kým nie je nastavená platná metóda."
   },
   "mechanisms": {
-    "heading": "Available update mechanisms",
-    "intro": "Depending on how the app was installed and where its updates come from, ProxMenux picks from three mechanisms.",
-    "osHeading": "Operating system packages",
-    "osP1": "On Debian or Ubuntu containers, ProxMenux queries and updates packages through APT. On Alpine, it uses APK.",
-    "osP2": "Registered apps whose install method is <code>dpkg</code> or <code>apk</code> are part of this pass. They don't need a second command in the app section — they update as part of <strong>Apply OS update</strong>.",
-    "osP3": "The section shows the number of pending packages, how many are security updates, the OS family and the time of the last check.",
-    "helperHeading": "Proxmox VE Helper-Scripts updater",
-    "helperP1": "When the LXC was created with a helper from the <linkHelperHome>Proxmox VE Helper-Scripts</linkHelperHome> project, ProxMenux recognises its updater. The matching app must be registered on the App tab so the Monitor can associate the helper with the service shown to the user.",
-    "helperP2": "<strong>The update logic itself is maintained by the Proxmox VE Helper-Scripts project</strong>, not by ProxMenux. Each helper ships its own <code>update_script</code> function; ProxMenux fetches it and runs it inside the container in silent mode (<code>PHS_SILENT=1</code>), without prompts. There is no need to copy the helper or write a custom command on the ProxMenux side.",
-    "helperP3": "Full documentation for the update mechanism lives on the project site — <linkHelperDocs>community-scripts.org / update-apps</linkHelperDocs>. Each helper also has its own entry on the <linkHelperHome>project site</linkHelperHome> with a description of what the script does, its default configuration and the source of the update logic — use that page as the reference for what the updater will change inside the LXC.",
-    "helperP4": "Not every helper supports in-place updates. If the catalog marks an application as non-upgradable, the tab will surface that state and won't present this method as available.",
-    "customHeading": "Custom command",
-    "customP1": "A registered app can store its own update command. ProxMenux runs it inside the LXC when the user presses <strong>Apply update</strong> or when a scheduled task includes that app.",
-    "customP2": "This method is designed for apps whose installer provides no recognised helper and that don't update as part of APT or APK."
+    "heading": "Dostupné mechanizmy aktualizácie",
+    "intro": "Podľa toho, ako bola aplikácia nainštalovaná a odkiaľ pochádzajú jej aktualizácie, vyberá ProxMenux z troch mechanizmov.",
+    "osHeading": "Balíky operačného systému",
+    "osP1": "V Debian alebo Ubuntu kontajneroch ProxMenux kontroluje a aktualizuje balíky cez APT. V Alpine používa APK.",
+    "osP2": "Registrované aplikácie, ktorých metóda inštalácie je <code>dpkg</code> alebo <code>apk</code>, sú súčasťou tejto kontroly. V sekcii aplikácie nepotrebujú druhý príkaz — aktualizujú sa spolu s akciou <strong>Použiť aktualizáciu OS</strong>.",
+    "osP3": "Sekcia zobrazuje počet čakajúcich balíkov, počet bezpečnostných aktualizácií, rodinu OS a čas poslednej kontroly.",
+    "helperHeading": "Aktualizátor Proxmox VE Helper-Scripts",
+    "helperP1": "Ak bol LXC vytvorený pomocou helpera z projektu <linkHelperHome>Proxmox VE Helper-Scripts</linkHelperHome>, ProxMenux rozpozná jeho aktualizátor. Príslušná aplikácia musí byť zaregistrovaná v záložke App, aby ju Monitor vedel prepojiť so službou zobrazenou používateľovi.",
+    "helperP2": "<strong>Samotnú logiku aktualizácie spravuje projekt Proxmox VE Helper-Scripts</strong>, nie ProxMenux. Každý helper má vlastnú funkciu <code>update_script</code>; ProxMenux ju stiahne a spustí vo vnútri kontajnera v tichom režime (<code>PHS_SILENT=1</code>), bez otázok. Na strane ProxMenuxu netreba helper kopírovať ani písať vlastný príkaz.",
+    "helperP3": "Úplná dokumentácia k mechanizmu aktualizácie je na stránke projektu — <linkHelperDocs>community-scripts.org / update-apps</linkHelperDocs>. Každý helper má zároveň vlastnú položku na <linkHelperHome>stránke projektu</linkHelperHome> s opisom toho, čo skript robí, aké má predvolené nastavenia a odkiaľ pochádza aktualizačná logika — túto stránku používajte ako referenciu pre to, čo aktualizátor zmení vo vnútri LXC.",
+    "helperP4": "Nie každý helper podporuje aktualizáciu na mieste. Ak katalóg označí aplikáciu ako neaktualizovateľnú, záložka tento stav zobrazí a túto metódu neponúkne ako dostupnú.",
+    "customHeading": "Vlastný príkaz",
+    "customP1": "Registrovaná aplikácia môže mať uložený vlastný aktualizačný príkaz. ProxMenux ho spustí vo vnútri LXC, keď používateľ klikne na <strong>Použiť aktualizáciu</strong> alebo keď ho zahrnie plánovaná úloha.",
+    "customP2": "Táto metóda je určená pre aplikácie, ktorých inštalátor neposkytuje rozpoznaného helpera a ktoré sa neaktualizujú cez APT alebo APK."
   },
   "decision": {
-    "heading": "How ProxMenux picks the action to show",
+    "heading": "Ako ProxMenux vyberá zobrazenú akciu",
     "table": {
-      "colSituation": "Situation",
-      "colAction": "Action",
+      "colSituation": "Situácia",
+      "colAction": "Akcia",
       "rows": [
-        { "situation": "APT or APK packages pending", "action": "Apply OS update" },
-        { "situation": "The app uses a dpkg or apk package", "action": "Apply OS update — no separate app command needed" },
-        { "situation": "A compatible helper exists and the app is registered", "action": "Apply update via Community Scripts" },
-        { "situation": "The registered app has a custom command", "action": "Apply update using that command" },
-        { "situation": "A new version exists but no helper or command is configured", "action": "Shows No updater configured; offers to add a command" },
-        { "situation": "System and app updates are both available", "action": "Combined Apply OS + Apps updates action may appear" }
+        { "situation": "Čakajú balíky APT alebo APK", "action": "Použiť aktualizáciu OS" },
+        { "situation": "Aplikácia používa dpkg alebo apk balík", "action": "Použiť aktualizáciu OS — samostatný príkaz aplikácie nie je potrebný" },
+        { "situation": "Existuje kompatibilný helper a aplikácia je registrovaná", "action": "Použiť aktualizáciu cez Community Scripts" },
+        { "situation": "Registrovaná aplikácia má vlastný príkaz", "action": "Použiť aktualizáciu týmto príkazom" },
+        { "situation": "Existuje nová verzia, ale nie je nastavený helper ani príkaz", "action": "Zobrazí Nie je nastavený aktualizátor a ponúkne pridanie príkazu" },
+        { "situation": "Dostupné sú systémové aj aplikačné aktualizácie", "action": "Môže sa zobraziť spoločná akcia Použiť aktualizácie OS + aplikácií" }
       ]
     },
-    "trailing": "An app registered only as a link is never shown as upgradable — ProxMenux doesn't have enough information to wire an update method to it."
+    "trailing": "Aplikácia registrovaná iba ako odkaz sa nikdy nezobrazí ako aktualizovateľná — ProxMenux nemá dosť informácií na prepojenie s metódou aktualizácie."
   },
   "figures": {
     "f01": {
-      "alt": "OS packages card showing pending updates count, security-updates count and the Apply OS update button",
-      "caption": "Pending OS packages: total count, security-updates count, and the Apply OS update button"
+      "alt": "Karta systémových balíkov s počtom čakajúcich aktualizácií, počtom bezpečnostných aktualizácií a tlačidlom Použiť aktualizáciu OS",
+      "caption": "Čakajúce systémové balíky: celkový počet, počet bezpečnostných aktualizácií a tlačidlo Použiť aktualizáciu OS"
     },
     "f02": {
-      "alt": "Same OS packages card after applying updates — no packages pending, OS up to date badge",
-      "caption": "After applying: 'No OS updates pending' and the OS up to date badge"
+      "alt": "Rovnaká karta systémových balíkov po aktualizácii — žiadne čakajúce balíky a štítok OS je aktuálny",
+      "caption": "Po použití: „Žiadne čakajúce aktualizácie OS“ a štítok OS je aktuálny"
     },
     "f03": {
-      "alt": "Registered app card showing 'No update method available' and an Add custom update command button",
-      "caption": "'No update method available' — ProxMenux tracks the app but has nothing wired to upgrade it yet"
+      "alt": "Karta registrovanej aplikácie so stavom Nie je dostupná metóda aktualizácie a tlačidlom Pridať vlastný aktualizačný príkaz",
+      "caption": "„Nie je dostupná metóda aktualizácie“ — ProxMenux aplikáciu sleduje, ale ešte nemá nastavené nič, čo by ju aktualizovalo"
     },
     "f04": {
-      "alt": "Custom update command editor with the example placeholder visible inside the textarea",
-      "caption": "The custom command editor with its placeholder example, Cancel and Save buttons"
+      "alt": "Editor vlastného aktualizačného príkazu s ukážkovým placeholderom v textovom poli",
+      "caption": "Editor vlastného príkazu s ukážkovým placeholderom, tlačidlami Zrušiť a Uložiť"
     },
     "f05": {
-      "alt": "Terminal panel labelled 'Apply updates — CT 103' showing live apt output as packages are unpacked",
-      "caption": "Terminal panel streaming the update output live while apt unpacks packages inside the CT"
+      "alt": "Terminálový panel s názvom Použiť aktualizácie — CT 103, ktorý zobrazuje živý apt výstup pri rozbaľovaní balíkov",
+      "caption": "Terminálový panel zobrazuje živý výstup aktualizácie, kým apt rozbaľuje balíky vo vnútri CT"
     },
     "f06": {
-      "alt": "Options card with snapshot before applying enabled, backup storage set to pbs, and restart after applying enabled",
-      "caption": "Options card with vzdump snapshot, backup storage and restart-after-applying enabled together"
+      "alt": "Karta možností so zapnutým snapshotom pred použitím, záložným úložiskom nastaveným na pbs a zapnutým reštartom po použití",
+      "caption": "Karta možností so súčasne zapnutým vzdump snapshotom, záložným úložiskom a reštartom po použití"
     },
     "f07": {
-      "alt": "Scheduled updates section enabled — Frequency set to Daily at 3:00, cron expression 0 3 * * *, and What to update set to OS + application",
-      "caption": "Scheduled updates enabled — frequency preset, matching cron expression and target scope selected"
+      "alt": "Sekcia plánovaných aktualizácií je zapnutá — frekvencia denne o 3:00, cron výraz 0 3 * * * a cieľ nastavený na OS + aplikácia",
+      "caption": "Plánované aktualizácie sú zapnuté — predvoľba frekvencie, zodpovedajúci cron výraz a vybraný rozsah aktualizácie"
     }
   },
   "custom": {
-    "heading": "Adding a custom update command",
-    "p1": "When an app has version tracking but no update method, the tab shows <strong>No updater configured</strong>. Press <strong>Add custom update command</strong> to open the editor.",
-    "p2": "The command must represent the real, complete procedure that upgrades that app. Don't just paste the command that reads its version."
+    "heading": "Pridanie vlastného aktualizačného príkazu",
+    "p1": "Keď má aplikácia sledovanie verzie, ale nemá metódu aktualizácie, záložka zobrazí <strong>Nie je nastavený aktualizátor</strong>. Kliknutím na <strong>Pridať vlastný aktualizačný príkaz</strong> otvoríte editor.",
+    "p2": "Príkaz musí predstavovať reálny a úplný postup, ktorý danú aplikáciu aktualizuje. Nevkladajte sem iba príkaz, ktorý číta jej verziu."
   },
   "figureOut": {
-    "heading": "How to figure out the correct command",
-    "intro": "There is no universal update command. Before saving one, identify how the software was installed and what the project's recommended upgrade path is.",
-    "step1Heading": "1. Check whether the system already handles it",
-    "step1P1": "If the app was installed from Debian, Ubuntu or Alpine repositories it usually upgrades with system packages. In that case don't add a custom command — use <strong>Apply OS update</strong>.",
-    "step1P2": "You can check the package origin from the LXC console with the distro's tooling. For example:",
+    "heading": "Ako zistiť správny príkaz",
+    "intro": "Neexistuje univerzálny aktualizačný príkaz. Pred uložením najprv zistite, ako bol softvér nainštalovaný a aký postup aktualizácie odporúča jeho projekt.",
+    "step1Heading": "1. Skontrolujte, či to už nerieši systém",
+    "step1P1": "Ak bola aplikácia nainštalovaná z repozitárov Debianu, Ubuntu alebo Alpine, zvyčajne sa aktualizuje spolu so systémovými balíkmi. Vtedy nepridávajte vlastný príkaz — použite <strong>Použiť aktualizáciu OS</strong>.",
+    "step1P2": "Pôvod balíka môžete overiť z konzoly LXC nástrojmi danej distribúcie. Napríklad:",
     "step1Cmd1": "dpkg -l | grep -i name",
-    "step1P3": "or:",
+    "step1P3": "alebo:",
     "step1Cmd2": "apk info | grep -i name",
-    "step1P4": "Replace <code>name</code> with the package you are investigating. A match doesn't automatically confirm it's the main package — cross-check the name against the app's documentation.",
-    "step2Heading": "2. Consult the official documentation",
-    "step2P1": "Look in the official docs or repository for sections like <strong>Upgrade</strong>, <strong>Update</strong>, <strong>Maintenance</strong> or <strong>Manual installation</strong>. The procedure must match the method used to install the app in that LXC.",
-    "step2P2": "Don't use instructions targeting a different distribution, a different install type or a different version.",
-    "step3Heading": "3. Inspect the existing installation",
-    "step3Lead": "If you don't remember how the app was installed, look at:",
+    "step1P4": "Nahraďte <code>name</code> balíkom, ktorý skúmate. Zhoda ešte automaticky nepotvrdzuje, že ide o hlavný balík — porovnajte názov s dokumentáciou aplikácie.",
+    "step2Heading": "2. Pozrite oficiálnu dokumentáciu",
+    "step2P1": "V oficiálnych dokumentoch alebo repozitári hľadajte sekcie ako <strong>Upgrade</strong>, <strong>Update</strong>, <strong>Maintenance</strong> alebo <strong>Manual installation</strong>. Postup musí zodpovedať spôsobu, akým je aplikácia nainštalovaná v danom LXC.",
+    "step2P2": "Nepoužívajte návody určené pre inú distribúciu, iný typ inštalácie alebo inú verziu.",
+    "step3Heading": "3. Skontrolujte existujúcu inštaláciu",
+    "step3Lead": "Ak si nepamätáte, ako bola aplikácia nainštalovaná, pozrite:",
     "step3Items": [
-      "The history or notes of the original installer.",
-      "The path where its files live.",
-      "The service definition that starts it.",
-      "Any maintenance scripts shipped by the app.",
-      "The documentation stored inside its install directory."
+      "Históriu alebo poznámky pôvodného inštalátora.",
+      "Cestu, kde sú uložené jej súbory.",
+      "Definíciu služby, ktorá ju spúšťa.",
+      "Údržbové skripty dodané aplikáciou.",
+      "Dokumentáciu uloženú v jej inštalačnom priečinku."
     ],
-    "step3P1": "For a systemd service, this can help locate the binary and its working directory:",
+    "step3P1": "Pri systemd službe môže toto pomôcť nájsť binárku a pracovný priečinok:",
     "step3Cmd": "systemctl show service-name -p ExecStart -p WorkingDirectory",
-    "step3P2": "This helps identify the installation, but it does not automatically translate the <code>ExecStart</code> line into an update command.",
-    "step4Heading": "4. Test the procedure in the LXC console",
-    "step4Lead": "Open a console into the container and run the procedure manually before saving it in ProxMenux. Verify that it:",
+    "step3P2": "Pomôže to identifikovať inštaláciu, ale automaticky to neznamená, že riadok <code>ExecStart</code> je aktualizačný príkaz.",
+    "step4Heading": "4. Otestujte postup v konzole LXC",
+    "step4Lead": "Otvorte konzolu kontajnera a spustite postup ručne ešte pred uložením do ProxMenuxu. Overte, že:",
     "step4Items": [
-      "Finishes without prompts or interactive menus.",
-      "Returns a correct exit code.",
-      "Restarts or reloads only the services that need it.",
-      "Leaves the app reachable afterwards.",
-      "Changes the installed version as expected."
+      "Skončí bez otázok alebo interaktívnych menu.",
+      "Vráti správny exit code.",
+      "Reštartuje alebo znovu načíta iba služby, ktoré to potrebujú.",
+      "Aplikácia je po ňom znovu dostupná.",
+      "Nainštalovaná verzia sa zmení podľa očakávania."
     ],
-    "step4Note": "When feasible, take a container backup before testing.",
-    "step5Heading": "5. Save only the in-container command",
-    "step5P1": "Enter only what would be executed inside the LXC. Don't include:",
+    "step4Note": "Ak je to možné, pred testom vytvorte zálohu kontajnera.",
+    "step5Heading": "5. Uložte iba príkaz spúšťaný vo vnútri kontajnera",
+    "step5P1": "Zadajte iba to, čo sa má vykonať vo vnútri LXC. Nevkladajte:",
     "step5Cmd1": "pct exec <vmid> --",
-    "step5P2": "ProxMenux already handles entering the container. The command runs as <code>root</code> via <code>sh -c</code>, so it accepts chained operations and directory changes.",
-    "step5P3": "If the updater must run from a specific path, include it explicitly:",
+    "step5P2": "ProxMenux už vstup do kontajnera rieši sám. Príkaz sa spúšťa ako <code>root</code> cez <code>sh -c</code>, takže podporuje reťazenie operácií aj zmenu priečinka.",
+    "step5P3": "Ak musí aktualizátor bežať z konkrétnej cesty, uveďte ju priamo:",
     "step5Cmd2": "cd /opt/my-app && ./update.sh",
-    "step5P4": "If the project ships an updater at a different path, use the path and arguments named by the official documentation."
+    "step5P4": "Ak projekt dodáva aktualizátor na inej ceste, použite cestu a argumenty uvedené v oficiálnej dokumentácii."
   },
   "requirements": {
-    "heading": "Requirements for a reliable command",
-    "lead": "Before running it from the Monitor, confirm the command:",
+    "heading": "Požiadavky na spoľahlivý príkaz",
+    "lead": "Pred spustením z Monitoru overte, že príkaz:",
     "items": [
-      "Runs without user interaction.",
-      "Uses absolute paths or changes into the correct directory first.",
-      "Stops, migrates and restarts services as required by the official instructions.",
-      "Exits with an error when the update fails.",
-      "Does not contain visible passwords, tokens or other secrets.",
-      "Does not download or execute scripts from untrusted sources."
+      "Beží bez zásahu používateľa.",
+      "Používa absolútne cesty alebo sa najprv prepne do správneho priečinka.",
+      "Zastaví, migruje a reštartuje služby tak, ako vyžadujú oficiálne pokyny.",
+      "Skončí chybou, ak aktualizácia zlyhá.",
+      "Neobsahuje viditeľné heslá, tokeny ani iné tajné údaje.",
+      "Nesťahuje ani nespúšťa skripty z nedôveryhodných zdrojov."
     ],
-    "trailing": "The content is stored in the LXC's configuration and executed with administrator privileges. Treat it with the same care as any command run as <code>root</code>."
+    "trailing": "Obsah sa ukladá do konfigurácie LXC a spúšťa sa s administrátorskými právami. Pristupujte k nemu rovnako opatrne ako ku každému príkazu spustenému ako <code>root</code>."
   },
   "difference": {
-    "heading": "Difference between the detection command and the update command",
-    "lead": "Both fields have different goals:",
+    "heading": "Rozdiel medzi detekčným a aktualizačným príkazom",
+    "lead": "Obe polia majú rozdielny účel:",
     "table": {
-      "colField": "Field",
-      "colLocation": "Location",
-      "colRole": "Role",
+      "colField": "Pole",
+      "colLocation": "Umiestnenie",
+      "colRole": "Úloha",
       "rows": [
         {
-          "field": "Command for the installed version",
-          "location": "App → advanced tracking",
-          "role": "Reads and returns the current version; executed as an argument list without a shell."
+          "field": "Príkaz pre nainštalovanú verziu",
+          "location": "App → pokročilé sledovanie",
+          "role": "Prečíta a vráti aktuálnu verziu; spúšťa sa ako zoznam argumentov bez shellu."
         },
         {
-          "field": "Custom update command",
-          "location": "Updates",
-          "role": "Runs the upgrade procedure; interpreted via sh -c."
+          "field": "Vlastný aktualizačný príkaz",
+          "location": "Aktualizácie",
+          "role": "Spúšťa aktualizačný postup; interpretuje sa cez sh -c."
         }
       ]
     },
-    "trailing": "Don't blindly copy the value of one into the other. A command like <code>myapp --version</code> may correctly detect the version but won't install a new one."
+    "trailing": "Nekopírujte slepo hodnotu z jedného poľa do druhého. Príkaz ako <code>myapp --version</code> môže správne zistiť verziu, ale nenainštaluje novú."
   },
   "apply": {
-    "heading": "Applying an update",
-    "lead": "Before pressing an apply button:",
+    "heading": "Použitie aktualizácie",
+    "lead": "Pred kliknutím na tlačidlo použitia:",
     "steps": [
-      "Confirm what will be updated: system, one app or both.",
-      "Check the backup and restart options.",
-      "Press the matching button.",
-      "Follow the process output in the terminal panel.",
-      "Verify the final result and that the service responds again."
+      "Overte, čo sa bude aktualizovať: systém, jedna aplikácia alebo oboje.",
+      "Skontrolujte možnosti zálohy a reštartu.",
+      "Kliknite na príslušné tlačidlo.",
+      "Sledujte výstup procesu v terminálovom paneli.",
+      "Overte výsledok a to, že služba znovu odpovedá."
     ],
-    "trailing1": "If the LXC is stopped, ProxMenux starts it to run the process. If the update finishes correctly and the restart option is enabled, the container is restarted at the end.",
-    "systemLead": "On a system update:",
+    "trailing1": "Ak je LXC zastavený, ProxMenux ho spustí, aby mohol proces prebehnúť. Ak aktualizácia skončí správne a je zapnutý reštart, kontajner sa na konci reštartuje.",
+    "systemLead": "Pri systémovej aktualizácii:",
     "systemItems": [
-      "Debian and Ubuntu run the upgrade via APT.",
-      "Alpine runs it via APK."
+      "Debian a Ubuntu spúšťajú upgrade cez APT.",
+      "Alpine ho spúšťa cez APK."
     ],
-    "appLead": "On an app update:",
+    "appLead": "Pri aktualizácii aplikácie:",
     "appItems": [
-      "The compatible helper is used, when it exists.",
-      "The custom command stored for the app is executed, when configured.",
-      "If several apps are selected, their methods run in sequence."
+      "Použije sa kompatibilný helper, ak existuje.",
+      "Spustí sa vlastný príkaz uložený pre aplikáciu, ak je nastavený.",
+      "Ak je vybraných viac aplikácií, ich metódy sa spustia postupne."
     ],
-    "trailing2": "The terminal panel shows progress and ends with a successful result or the process's error code."
+    "trailing2": "Terminálový panel zobrazuje priebeh a skončí úspešným výsledkom alebo chybovým kódom procesu."
   },
   "backup": {
-    "heading": "Backup before updating",
-    "p1": "Enable <strong>Snapshot the container before applying</strong> to create a <code>vzdump</code> backup before touching the LXC. You can also choose the target storage.",
-    "p2": "If the backup is requested and it fails, ProxMenux won't continue with the update. This prevents changes from starting without the requested recovery point.",
-    "p3": "This option applies to both manual runs and scheduled runs."
+    "heading": "Záloha pred aktualizáciou",
+    "p1": "Zapnite <strong>Snapshot kontajnera pred použitím</strong>, aby sa pred zásahom do LXC vytvorila záloha <code>vzdump</code>. Môžete vybrať aj cieľové úložisko.",
+    "p2": "Ak je záloha vyžadovaná a zlyhá, ProxMenux nebude v aktualizácii pokračovať. Zmeny sa tak nezačnú bez požadovaného bodu obnovy.",
+    "p3": "Táto voľba platí pre ručné spustenia aj plánované úlohy."
   },
   "restart": {
-    "heading": "Restart after updating",
-    "p1": "<strong>Restart the container after applying</strong> is a preference, not a signal that the restart is mandatory. Enable it when the app's procedure or the installed packages require it.",
-    "p2": "The restart only happens after a successful run. If the update fails, the container stays up so the error can be inspected.",
-    "p3": "The backup and restart options are saved for that LXC and also apply to its scheduled tasks."
+    "heading": "Reštart po aktualizácii",
+    "p1": "<strong>Reštartovať kontajner po použití</strong> je preferencia, nie dôkaz, že reštart je povinný. Zapnite ju, keď to vyžaduje postup aplikácie alebo nainštalované balíky.",
+    "p2": "Reštart nastane iba po úspešnom behu. Ak aktualizácia zlyhá, kontajner ostane spustený, aby sa dala chyba skontrolovať.",
+    "p3": "Možnosti zálohy a reštartu sa ukladajú pre dané LXC a platia aj pre jeho plánované úlohy."
   },
   "scheduled": {
-    "heading": "Scheduled updates",
-    "p1": "The <strong>Scheduled updates</strong> section runs automatically the same flow the manual buttons use.",
-    "createLead": "To create a schedule:",
+    "heading": "Plánované aktualizácie",
+    "p1": "Sekcia <strong>Plánované aktualizácie</strong> automaticky spúšťa rovnaký tok, aký používajú ručné tlačidlá.",
+    "createLead": "Plán vytvoríte takto:",
     "createSteps": [
-      "Open <strong>Options</strong> and press <strong>Edit</strong>.",
-      "Enable <strong>Scheduled updates</strong>.",
-      "Choose a preset frequency or enter a cron expression.",
-      "Select what will be updated: system packages only, applications only, or system and applications.",
-      "Review the backup and restart options.",
-      "Save the configuration."
+      "Otvorte <strong>Možnosti</strong> a kliknite na <strong>Upraviť</strong>.",
+      "Zapnite <strong>Plánované aktualizácie</strong>.",
+      "Vyberte predvolenú frekvenciu alebo zadajte cron výraz.",
+      "Vyberte, čo sa bude aktualizovať: iba systémové balíky, iba aplikácie alebo systém aj aplikácie.",
+      "Skontrolujte možnosti zálohy a reštartu.",
+      "Uložte nastavenie."
     ],
-    "p2": "The card shows whether the schedule is active, what it covers and the outcome of the last run. A disabled schedule can be kept for later re-activation, or removed entirely.",
-    "p3": "If ProxMenux detects an external schedule created by Community Scripts on the host, it surfaces it so the user knows another automation is already in place.",
-    "callout": "Before scheduling app updates, test every helper or command manually. A scheduled task can't answer prompts or fix an incomplete procedure."
+    "p2": "Karta zobrazuje, či je plán aktívny, čo zahŕňa a ako dopadol posledný beh. Vypnutý plán môžete ponechať na neskoršie zapnutie alebo ho úplne odstrániť.",
+    "p3": "Ak ProxMenux na hostiteľovi nájde externý plán vytvorený cez Community Scripts, zobrazí ho, aby používateľ vedel, že už existuje iná automatizácia.",
+    "callout": "Pred plánovaním aktualizácií aplikácií ručne otestujte každý helper alebo príkaz. Plánovaná úloha nevie odpovedať na otázky ani opraviť neúplný postup."
   },
   "verify": {
-    "heading": "Checking the result",
-    "p1": "After applying system packages, ProxMenux forces a fresh check to update the pending-package counter without waiting for the next periodic cycle.",
-    "p2": "For an app, go back to the <link>App tab</link> and press <strong>Check</strong> if the version number doesn't refresh immediately. This runs the configured installed-version method again and queries the upstream source.",
-    "p3": "Confirm additionally that the app's web links respond correctly. A command finishing without errors is not a substitute for functional verification of the service."
+    "heading": "Kontrola výsledku",
+    "p1": "Po použití systémových balíkov ProxMenux vynúti čerstvú kontrolu, aby sa počítadlo čakajúcich balíkov aktualizovalo bez čakania na ďalší pravidelný cyklus.",
+    "p2": "Pri aplikácii sa vráťte do <link>záložky App</link> a kliknite na <strong>Skontrolovať</strong>, ak sa číslo verzie neobnoví hneď. Znovu sa spustí nastavená metóda nainštalovanej verzie a dotaz na upstream zdroj.",
+    "p3": "Navyše overte, že webové odkazy aplikácie správne odpovedajú. Príkaz, ktorý skončí bez chýb, ešte nenahrádza funkčnú kontrolu služby."
   },
   "troubleshoot": {
-    "heading": "Common problems",
-    "noButtonHeading": "Update available appears, but there's no Apply update button",
-    "noButtonBody": "Version detection works, but no method to install the update was found. Check whether the app updates via system packages, a compatible helper or a custom command.",
-    "aptHeading": "The app updates through APT or APK",
-    "aptBody": "Use <strong>Apply OS update</strong>. Don't add a second command for the same operation — the app is already part of the system update.",
-    "noUpdaterHeading": "No updater configured is shown",
-    "noUpdaterBody": "ProxMenux tracks the app but doesn't know how to update it. Check its official documentation, test the procedure in the console and, if appropriate, save it via <strong>Add custom update command</strong>.",
-    "helperDetectedHeading": "The helper is detected but can't be used",
-    "helperDetectedBody": "The helper may be marked as non-upgradable or fall outside the recognised methods. Follow the app's official instructions and don't assume every LXC built with Community Scripts supports automatic updates.",
-    "customFailsHeading": "The custom command fails",
-    "customFailsBody": "Re-run it in the LXC console. Check the working path, permissions, dependencies, non-interactive arguments and exit code. Don't swap the command for a different variant until you've verified the recommended procedure with the project."
+    "heading": "Časté problémy",
+    "noButtonHeading": "Zobrazuje sa Dostupná aktualizácia, ale chýba tlačidlo Použiť aktualizáciu",
+    "noButtonBody": "Detekcia verzie funguje, ale nenašla sa metóda na inštaláciu aktualizácie. Skontrolujte, či sa aplikácia aktualizuje cez systémové balíky, kompatibilného helpera alebo vlastný príkaz.",
+    "aptHeading": "Aplikácia sa aktualizuje cez APT alebo APK",
+    "aptBody": "Použite <strong>Použiť aktualizáciu OS</strong>. Nepridávajte druhý príkaz pre rovnakú operáciu — aplikácia už je súčasťou systémovej aktualizácie.",
+    "noUpdaterHeading": "Zobrazuje sa Nie je nastavený aktualizátor",
+    "noUpdaterBody": "ProxMenux aplikáciu sleduje, ale nevie, ako ju aktualizovať. Skontrolujte jej oficiálnu dokumentáciu, otestujte postup v konzole a ak je vhodný, uložte ho cez <strong>Pridať vlastný aktualizačný príkaz</strong>.",
+    "helperDetectedHeading": "Helper je nájdený, ale nedá sa použiť",
+    "helperDetectedBody": "Helper môže byť označený ako neaktualizovateľný alebo nespadá medzi rozpoznané metódy. Riaďte sa oficiálnymi pokynmi aplikácie a nepredpokladajte, že každý LXC vytvorený cez Community Scripts podporuje automatické aktualizácie.",
+    "customFailsHeading": "Vlastný príkaz zlyhá",
+    "customFailsBody": "Spustite ho znovu v konzole LXC. Skontrolujte pracovnú cestu, oprávnenia, závislosti, neinteraktívne argumenty a exit code. Nemeňte príkaz za inú verziu, kým neoveríte odporúčaný postup podľa projektu."
   }
 }


### PR DESCRIPTION
## Summary
- translate the new Slovak VM/LXC App documentation page
- translate the new Slovak VM/LXC Updates documentation page
- keep technical terms, commands, package names, and regex examples intact

## Testing
- validated both Slovak JSON files parse correctly
- compared Slovak vs English message structure: missing=0, extra=0 for both files
- ran `npm run build` in `web` successfully
- checked local docs preview returns HTTP 200 for the Slovak App and Updates pages
- visually reviewed both Slovak pages in the browser