### PR TITLE
i18n: polish Slovak monitor copy

### DIFF
--- a/AppImage/components/lxc-app-panel.tsx
+++ b/AppImage/components/lxc-app-panel.tsx
@@ -1765,7 +1765,7 @@ export function LxcAppPanel({ vmid, ctIp, onChange, managed, initialData }: Prop
                     )}
                     {tracking && st?.checked_at && (
                       <div className="text-[10px] text-muted-foreground/80 mt-0.5">
-                        Checked {new Date(st.checked_at).toLocaleString([], { dateStyle: "short", timeStyle: "short" })}
+                        {t("vmLxc.appEditor.checkedAt", { date: new Date(st.checked_at).toLocaleString([], { dateStyle: "short", timeStyle: "short" }) })}
                       </div>
                     )}
                     {/* Mobile-only repo link: falls into the metadata

--- a/AppImage/messages/sk/common.json
+++ b/AppImage/messages/sk/common.json
@@ -1,7 +1,7 @@
 {
   "app": {
     "title": "ProxMenux Monitor",
-    "description": "Proxmox System Dashboard",
+    "description": "Prehľad systému Proxmox",
     "loading": "Načítava sa...",
     "connecting": "Pripájam sa k ProxMenux Monitoru",
     "unknown": "Neznáme",
@@ -1021,7 +1021,7 @@
         "stopped": "vypnuté",
         "mounted": "pripojené"
       },
-      "startOnBoot": "Začnite pri štarte",
+      "startOnBoot": "Spúšťať pri štarte",
       "tags": "Značky",
       "tagsPlaceholder": "Pridať značku…",
       "tagsNone": "Žiadne značky"
@@ -1272,7 +1272,7 @@
       "postApplyAllOk": "{count} balíkov bolo úspešne použitých – nič sa nečaká.",
       "postApplyNothingPending": "Nič sa nečaká – všetko je aktuálne.",
       "postApplyPartial": "{pending} balíkov, ktoré po spustení stále čakajú.",
-      "postApplyPartialSubline": "Použilo sa {applied}.Niektoré aktualizácie sa nedokončili – skontrolujte výstup terminálu vyššie."
+      "postApplyPartialSubline": "Použilo sa {applied}. Niektoré aktualizácie sa nedokončili – skontrolujte výstup terminálu vyššie."
     },
     "appEditor": {
       "closePanel": "Zavrieť panel",
@@ -1862,9 +1862,9 @@
       }
     },
     "optimizations": {
-      "title": "ProxMenux Optimizations",
+      "title": "Systémové optimalizácie",
       "description": "Systémové optimalizácie a nástroje nainštalované cez ProxMenux",
-      "emptyTitle": "Zatiaľ nie sú nainštalované žiadne optimalizácie ProxMenux",
+      "emptyTitle": "Zatiaľ nie sú nainštalované žiadne systémové optimalizácie",
       "emptyDescription": "Spustite ProxMenux a nastavte systémové optimalizácie",
       "installedTools": "Nainštalované nástroje",
       "activeCount": "{count} aktívne",


### PR DESCRIPTION
This is a small Slovak-only UI copy polish for the Monitor dashboard.

Changes:
- Translate the app subtitle to Slovak: `Prehľad systému Proxmox`
- Improve the VM/LXC start-on-boot label: `Spúšťať pri štarte`
- Use the existing i18n key for app check timestamps, so Slovak shows `Skontrolované ...` instead of hardcoded `Checked ...`
- Rename the Slovak settings card from `Optimalizácie ProxMenux` to `Systémové optimalizácie`, which better matches that these are system/Proxmox host optimizations managed through ProxMenux
- Fix a missing space in one Slovak update result message

Scope:
- Slovak translation only
- No English/base text changes
- No behavior changes

Validation:
- `jq empty AppImage/messages/sk/common.json AppImage/messages/en/common.json`
- `npm run build`
- Deployed and visually checked on a test ProxMenux Monitor instance