### PR TITLE
fix: report Proxmox update failures correctly

### DIFF
--- a/scripts/global/update-pve-safe.sh
+++ b/scripts/global/update-pve-safe.sh
@@ -104,26 +104,26 @@ update_pve_safe() {
         return 1
     fi
 
-    # Reachability check: HEAD https://download.proxmox.com over the same
-    # transport apt-get update will use (HTTPS 443). Previously a single
-    # ICMP ping — hosts behind firewalls that filter ICMP but allow 443
-    # (typical corporate / cloud-provider setups) hit a false negative
-    # and the update aborted even though the repository was reachable.
-    # Two attempts with a short pause absorb transient network glitches
-    # without adding perceptible latency when the network is healthy.
+    # Reachability check: probe the public Proxmox repository over the
+    # transport apt is most likely to use. Many PVE installs use the
+    # official HTTP apt URI, while HTTPS may fail before apt ever runs
+    # if the CDN presents a certificate for another Proxmox hostname.
+    # Accept either transport and let apt-get update report repo-specific
+    # errors in the next step.
     _repo_reachable() {
-        local url="https://download.proxmox.com/"
-        local attempt
-        for attempt in 1 2; do
-            if curl -sfI --connect-timeout 5 --max-time 10 -o /dev/null "$url"; then
-                return 0
-            fi
-            [[ $attempt -eq 1 ]] && sleep 1
+        local url attempt
+        for url in "http://download.proxmox.com/" "https://download.proxmox.com/"; do
+            for attempt in 1 2; do
+                if curl -sfI --connect-timeout 5 --max-time 10 -o /dev/null "$url"; then
+                    return 0
+                fi
+                [[ $attempt -eq 1 ]] && sleep 1
+            done
         done
         return 1
     }
     if ! _repo_reachable; then
-        msg_error "$(translate "Cannot reach https://download.proxmox.com (HTTPS 443). Check network, proxy or DNS.")"
+        msg_error "$(translate "Cannot reach download.proxmox.com. Check network, proxy or DNS.")"
         echo -e
         msg_success "$(translate "Press Enter to return to menu...")"
         read -r

--- a/scripts/utilities/proxmox_update.sh
+++ b/scripts/utilities/proxmox_update.sh
@@ -86,6 +86,8 @@ apt_upgrade() {
     # Single worker for both PVE 8 and 9 — it detects the version itself
     # and only performs operations safe on a production host.
     bash "$LOCAL_SCRIPTS/global/update-pve-safe.sh"
+    local worker_rc=$?
+    return "$worker_rc"
 
 
 }
@@ -162,11 +164,14 @@ check_reboot() {
 
 
 apt_upgrade
-check_reboot
+update_rc=$?
+if [[ "$update_rc" -eq 0 ]]; then
+    check_reboot
+else
+    exit "$update_rc"
+fi
 
     
-
-
 
 
 


### PR DESCRIPTION
## Summary

This is a small follow-up to the `update-pve-safe.sh` reachability work discussed in #271.

On a PVE 9.2.10 host, the Monitor system update flow showed an error from the safe update worker, but the outer wrapper still continued with cleanup and exited with code 0. The UI therefore displayed the run as successful even though one security update was still pending.

Observed case:

- active Proxmox apt source uses `http://download.proxmox.com/debian/pve`
- disabled enterprise/test sources are present but not active
- `curl -I https://download.proxmox.com/` fails with certificate hostname mismatch because the endpoint presents a certificate for `enterprise.proxmox.com`
- `curl -I http://download.proxmox.com/` succeeds
- `update-pve-safe.sh` returns failure before apt runs
- `proxmox_update.sh` ignores that failure, runs final cleanup and exits 0

## Changes

- Propagate the exit code from `scripts/global/update-pve-safe.sh` through `scripts/utilities/proxmox_update.sh`.
- Only run reboot/cleanup success handling when the safe update worker succeeds.
- Let the repository preflight accept either HTTP or HTTPS for `download.proxmox.com`, then leave repo-specific failures to the following `apt-get update` step.

## Validation

- `bash -n scripts/utilities/proxmox_update.sh`
- `bash -n scripts/global/update-pve-safe.sh`
- Checked the affected host sources: active Proxmox repo is HTTP, enterprise/test sources are disabled.
- Deployed the two changed scripts to a test ProxMenux Monitor instance on PVE 9.2.10.
- Ran the system update from the Monitor UI in a browser.
- The update no longer fails at the HTTPS-only preflight.
- The pending security update was applied successfully.
- Post-run verification showed 0 pending updates and 0 security updates.