### PR TITLE
fix(login): auto-submit completed 2FA code

### DIFF
--- a/AppImage/components/login.tsx
+++ b/AppImage/components/login.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { Button } from "./ui/button"
 import { Input } from "./ui/input"
 import { Label } from "./ui/label"
@@ -26,6 +26,7 @@ export function Login({ onLogin }: LoginProps) {
   const [showPassword, setShowPassword] = useState(false)
   const [error, setError] = useState("")
   const [loading, setLoading] = useState(false)
+  const lastAutoSubmittedTotp = useRef("")
 
   useEffect(() => {
     // The Login screen is, by construction, the recovery path from any
@@ -53,16 +54,17 @@ export function Login({ onLogin }: LoginProps) {
     }
   }, [])
 
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const submitLogin = async (totpOverride?: string) => {
     setError("")
+
+    const token = totpOverride ?? totpCode
 
     if (!username || !password) {
       setError(t("login.missingCredentials"))
       return
     }
 
-    if (requiresTotp && !totpCode) {
+    if (requiresTotp && !token) {
       setError(t("login.missingTotp"))
       return
     }
@@ -76,7 +78,7 @@ export function Login({ onLogin }: LoginProps) {
         body: JSON.stringify({
           username,
           password,
-          totp_token: totpCode || undefined, // Include 2FA code if provided
+          totp_token: token || undefined, // Include 2FA code if provided
         }),
       })
 
@@ -120,6 +122,22 @@ export function Login({ onLogin }: LoginProps) {
       setLoading(false)
     }
   }
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await submitLogin()
+  }
+
+  useEffect(() => {
+    if (!requiresTotp || loading || !/^\d{6}$/.test(totpCode)) {
+      return
+    }
+    if (lastAutoSubmittedTotp.current === totpCode) {
+      return
+    }
+    lastAutoSubmittedTotp.current = totpCode
+    void submitLogin(totpCode)
+  }, [requiresTotp, totpCode, loading])
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
@@ -245,9 +263,9 @@ export function Login({ onLogin }: LoginProps) {
                     type="text"
                     placeholder="000000"
                     value={totpCode}
-                    onChange={(e) => setTotpCode(e.target.value.replace(/\D/g, "").slice(0, 6))}
+                    onChange={(e) => setTotpCode(e.target.value.toUpperCase().replace(/[^A-Z0-9-]/g, "").slice(0, 9))}
                     className="text-center text-lg tracking-widest font-mono text-base"
-                    maxLength={6}
+                    maxLength={9}
                     disabled={loading}
                     autoComplete="one-time-code"
                     autoFocus


### PR DESCRIPTION
## Summary

This is a small login UX fix for the 2FA step.

The 2FA form currently relies on the browser/password manager or the user pressing the submit button after a TOTP code is filled. That can behave differently depending on the UI language. In testing, 1Password auto-submitted the 2FA code in English, but not in Slovak.

## Changes

- Auto-submit the login form when the 2FA step contains a complete 6-digit TOTP code.
- Keep the manual **Verify code** button and Enter-submit behavior.
- Keep backup-code entry possible by allowing the `XXXX-XXXX` format in the same field.
- Only auto-submit plain 6-digit numeric TOTP codes, not backup codes.

## Validation

- `npm run build` in `AppImage`
- Deployed the build to a test ProxMenux Monitor instance on PVE 9.2.10.
- Tested login through the browser with 1Password/TOTP in English, Slovak, and Spanish UI.
- In all tested languages, the completed 6-digit TOTP code submitted automatically and login succeeded.